### PR TITLE
Add remote downloader processor

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: 🏗️ Sphinx build
         run: |
+          make checklinks
           make rebuild-html
 
       - name: 📦 Upload build artifacts

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: 🏗️ Sphinx build
         run: |
-          make checklinks
           make rebuild-html
 
       - name: 📦 Upload build artifacts

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = docs
 BUILDDIR      = docs/_build
 PROJECTNAME   = musify
+LINKCHECKDIR  = docs/_linkcheck
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -18,6 +19,7 @@ rebuild-html: Makefile
 	rm -f docs/"$(PROJECTNAME)"*.rst
 	sphinx-apidoc -o "$(SOURCEDIR)" ./"$(PROJECTNAME)" -d 4 --force --module-first --separate --no-toc -t "$(SOURCEDIR)"/_templates
 	$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For more detailed guides, check out the [documentation](https://geo-martino.gith
 > - Load some other Spotify objects
 > - Add some tracks to a playlist
 
-1. If you don't already have one, create a [Spotify for Developers](https://developer.spotify.com/dashboard/login) account. 
+1. If you don't already have one, create a [Spotify for Developers](https://developer.spotify.com/dashboard) account. 
 2. If you don't already have one, [create an app](https://developer.spotify.com/documentation/web-api/concepts/apps). 
    Select "Web API" when asked which APIs you are planning on using. 
    To use this program, you will only need to take note of the **client ID** and **client secret**.
@@ -299,8 +299,8 @@ For more detailed guides, check out the [documentation](https://geo-martino.gith
 ## Currently Supported
 
 - **Music Streaming Services**: `Spotify`
-- **Audio filetypes**: `.mp3` `.flac` `.m4a` `.wma`
-- **Local playlist filetypes**: `.xautopf` `.m3u`
+- **Audio filetypes**: `.flac` `.m4a` `.mp3` `.wma`
+- **Local playlist filetypes**: `.m3u` `.xautopf`
 - **Local Libraries**: `MusicBee`
 
 

--- a/README.template.md
+++ b/README.template.md
@@ -70,7 +70,7 @@ For more detailed guides, check out the [documentation](https://{program_owner_u
 > - Load some other Spotify objects
 > - Add some tracks to a playlist
 
-1. If you don't already have one, create a [Spotify for Developers](https://developer.spotify.com/dashboard/login) account. 
+1. If you don't already have one, create a [Spotify for Developers](https://developer.spotify.com/dashboard) account. 
 2. If you don't already have one, [create an app](https://developer.spotify.com/documentation/web-api/concepts/apps). 
    Select "Web API" when asked which APIs you are planning on using. 
    To use this program, you will only need to take note of the **client ID** and **client secret**.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -7,7 +7,7 @@ To contribute to Musify, follow these steps:
 Setup your development environment
 ==================================
 1. Ensure you have Python3.12 or greater installed on your system.
-2. Go to the `GitHub repository <https://geo-martino.github.com/musify>`_ and fork the project by clicking
+2. Go to the `GitHub repository <https://github.com/geo-martino/musify>`_ and fork the project by clicking
    **Fork** in the top left:
 
    .. image:: _images/contributing/musify_fork.png

--- a/docs/howto.library.backup-restore.rst
+++ b/docs/howto.library.backup-restore.rst
@@ -55,7 +55,7 @@ Backup and restore a remote library
 1. Load a remote library. For more information on how to do this see any of
    the relevant guides for loading remote libraries.
 
-   Note:
+   .. note::
       This step uses the ``SpotifyLibrary``, but any supported music streaming service
       can be used in generally the same way. Just modify the imports and classes as required.
 

--- a/docs/howto.remote.new-music.rst
+++ b/docs/howto.remote.new-music.rst
@@ -15,7 +15,7 @@ Create the playlist
 
 1. Create a remote library object:
 
-   Note:
+   .. note::
       This step uses the ``SpotifyLibrary``, but any supported music streaming service
       can be used in generally the same way. Just modify the imports and classes as required.
 

--- a/docs/howto.spotify.load.rst
+++ b/docs/howto.spotify.load.rst
@@ -14,7 +14,7 @@ In this example, you will:
 Setup the Spotify API
 ---------------------
 
-1. If you don't already have one, create a `Spotify for Developers <https://developer.spotify.com/dashboard/login>`_ account.
+1. If you don't already have one, create a `Spotify for Developers <https://developer.spotify.com/dashboard>`_ account.
 
 2. If you don't already have one, `create an app <https://developer.spotify.com/documentation/web-api/concepts/apps>`_.
    Select "Web API" when asked which APIs you are planning on using.
@@ -22,9 +22,10 @@ Setup the Spotify API
 
 3. Create a ``SpotifyAPI`` object and authorise the program access to Spotify data as follows:
 
-   **NOTE:**
-   The scopes listed in this example will allow access to read your library data and write to your playlists.
-   See Spotify Web API documentation for more information about [scopes](https://developer.spotify.com/documentation/web-api/concepts/scopes)
+   .. note::
+      The scopes listed in this example will allow access to read your library data and write to your playlists.
+      See Spotify Web API documentation for more information about
+      `scopes <https://developer.spotify.com/documentation/web-api/concepts/scopes>`_
 
    .. literalinclude:: _howto/scripts/spotify.api.py
       :language: Python
@@ -47,7 +48,8 @@ Load your library
 
 3. Add some tracks to a playlist in your library, synchronise with Spotify, and log the results as follows:
 
-   **NOTE**: This step will only work if you chose to load either your playlists or your entire library in step 4.
+   .. note::
+      This step will only work if you chose to load either your playlists or your entire library in step 4.
 
    .. literalinclude:: _howto/scripts/spotify.load.py
       :language: Python

--- a/docs/howto.sync.rst
+++ b/docs/howto.sync.rst
@@ -6,7 +6,7 @@ In this example, you will:
    * Get tags and images for a track from a music stream service and save it them to your local track file
    * Create remote playlists from your local playlists
 
-Note:
+.. note::
    This guide will use Spotify, but any supported music streaming service can be used in generally the same way.
    Just modify the imports and classes as required.
 
@@ -35,7 +35,8 @@ Sync data
 
 3. Load the matched tracks, get tags from the music streaming service, and save the tags to the file:
 
-   **NOTE**: By default, URIs are saved to the ``comments`` tag.
+   .. note::
+      By default, URIs are saved to the ``comments`` tag.
 
    .. literalinclude:: _howto/scripts/sync.py
       :language: Python

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -35,6 +35,32 @@ This project adheres to a modified `Calendar Versioning <https://calver.org/>`_ 
 * ``M`` = The current month
 * ``P`` = An 0-indexed incrementing index for the release version for this month
 
+2024.1.5
+========
+
+Added
+-----
+
+* Add the ItemDownloadHelper general processor
+
+Changed
+-------
+
+* Factor out logging handlers to their own script to avoid circular import issues
+* Abstract away input methods of RemoteItemChecker to InputProcessor base class
+* Factor out patch_input method to function in InputProcessor derived tests
+
+Fixed
+-----
+
+* Captured stdout assertions in RemoteItemChecker tests re-enabled, now fixed
+
+Documentation
+-------------
+
+* Fix redirect/broken links
+* Change notes text to proper rst syntax
+
 
 2024.1.4
 ========
@@ -42,12 +68,12 @@ This project adheres to a modified `Calendar Versioning <https://calver.org/>`_ 
 Fixed
 -----
 
-* fixed bug in ``restore_tracks`` method on library due to 'images' tag name not being present in track properties
+* Fix bug in ``restore_tracks`` method on library due to 'images' tag name not being present in track properties
 
 Documentation
 -------------
 
-* Expanded docstrings across entire package
+* Expand docstrings across entire package
 * Expand documentation with how to section, release history, and contributions pages
 
 
@@ -57,7 +83,7 @@ Documentation
 Changed
 -------
 
-* Removed x10 factor on bar threshold on _get_items_multi function in SpotifyAPI
+* Remove x10 factor on bar threshold on _get_items_multi function in SpotifyAPI
 
 Fixed
 -----

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -54,6 +54,8 @@ Fixed
 -----
 
 * Captured stdout assertions in RemoteItemChecker tests re-enabled, now fixed
+* Surround RemoteApi 'user' properties in try-except block so they can still be
+  pretty printed even if API is not authorised
 
 Documentation
 -------------

--- a/logging.yml
+++ b/logging.yml
@@ -50,7 +50,7 @@ handlers:
     stream: ext://sys.stdout
 
   file:
-    class: musify.shared.logger.CurrentTimeRotatingFileHandler
+    class: musify.shared.handlers.CurrentTimeRotatingFileHandler
     level: DEBUG
     formatter: extended
     filters: ["file"]

--- a/make.bat
+++ b/make.bat
@@ -39,6 +39,7 @@ goto end
 rm docs/%PROJECTNAME%*.rst
 sphinx-apidoc -o %SOURCEDIR% ./%PROJECTNAME% -d 4 --force --module-first --separate --no-toc -t %SOURCEDIR%/_templates
 %SPHINXBUILD% -M html %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+%SPHINXBUILD% -b linkcheck %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
 
 :end

--- a/musify/processors/download.py
+++ b/musify/processors/download.py
@@ -1,0 +1,140 @@
+import re
+from collections.abc import Iterable, Collection
+from itertools import batched
+from typing import Any
+from webbrowser import open as webopen
+
+from musify.processors.base import InputProcessor, ItemProcessor
+from musify.shared.core.base import Item
+from musify.shared.core.collection import ItemCollection
+from musify.shared.core.enum import Field, Fields
+from musify.shared.exception import MusifyEnumError
+from musify.shared.types import UnitIterable
+from musify.shared.utils import to_collection
+
+
+class ItemDownloadHelper(InputProcessor, ItemProcessor):
+    """
+    Runs operations for helping the user to download items from given collections.
+
+    :param urls: The template URLs for websites to open queries for.
+        The given sites should contain exactly 1 '{}' placeholder into which the processor can place
+        a query for the item being searched. e.g. *bandcamp.com/search?q={}&item_type=t*
+    :param fields: The default fields to take from an item for use as the query string when initially opening sites.
+    :param interval: The number of items to open sites for before pausing for user input.
+    """
+
+    def __init__(self, urls: UnitIterable[str], fields: UnitIterable[Field] = Fields.ALL, interval: int = 1):
+        super().__init__()
+
+        self.urls: list[str] = to_collection(urls, list)
+        if fields == Fields.ALL or Fields.ALL in to_collection(fields, set):
+            fields = Fields.all()
+        self.fields: list[Field] = to_collection(fields, list)
+        self.interval = interval
+
+    def open_sites(self, collections: UnitIterable[ItemCollection]) -> None:
+        if isinstance(collections, ItemCollection):
+            items = collections.items
+        else:
+            items = [item for coll in collections for item in coll]
+
+        pages_total = (len(items) // self.interval) + (len(items) % self.interval > 0)
+        for page, items in enumerate(batched(items, self.interval), 1):
+            not_queried = self._open_sites_for_items(items=items, fields=self.fields)
+            self._pause(items=items, not_queried=not_queried, page=page, total=pages_total)
+
+    def _open_sites_for_items(self, items: Iterable[Item], fields: Iterable[Field]) -> list[Item]:
+        not_queried = []
+        for item in items:
+            queried = self._open_sites_for_item(item=item, fields=fields)
+            if not queried:
+                not_queried.append(item)
+
+        return not_queried
+
+    def _open_sites_for_item(self, item: Item, fields: Iterable[Field]) -> bool:
+        query_parts = []
+        for field in fields:
+            field_name = field.name.lower()
+            if not hasattr(item, field_name) or getattr(item, field_name) is None:
+                continue
+
+            value = getattr(item, field_name)
+            if isinstance(value, (tuple, set, list, dict)):
+                value = " ".join(value)
+            query_parts.append(str(value))
+
+        query = " ".join(query_parts)
+        if not query:
+            self.logger.debug(f"Could not get query for item: {item.name}")
+            return False
+
+        self.logger.debug(f"Opening {len(self.urls)} URLs with query: {query}")
+        for url in self.urls:
+            webopen(url.format(query))
+
+        return True
+
+    def _pause(self, items: Iterable[Item], not_queried: Collection[Item], page: int, total: int):
+        opened = len(self.urls) * (self.interval - len(not_queried))
+        not_opened = f" - Could not open sites for {len(not_queried)} items. " if not_queried else ". "
+        valid_fields = [
+            field.name.lower() for field in Fields.all()
+            if any(hasattr(item, field.name.lower()) for item in items)
+        ]
+
+        header = [
+            f"\t\33[1;94mOpened {opened} sites" + not_opened + "You may now search for and download the items. \33[0m"
+        ]
+        options = {
+            "<Return/Enter>": "Once you are finished with this batch, continue on to the next batch",
+            "r": "Re-open all sites for the current batch of items",
+            "<Fields>":
+                "Re-open all sites for the current batch of items using the input list of fields, "
+                "each separated by a space e.g. title artist album",
+        }
+
+        if not_queried:
+            options["n <Fields>"] = (
+                f"Same as above, but only open sites for the {len(not_queried)} items "
+                "which sites could not be opened for"
+            )
+        options["h"] = "Show this dialogue again"
+
+        current_input = "START"
+        help_text = self._format_help_text(options=options, header=header)
+        help_text += f"\n\t\33[90mValid <fields> for this batch: {" ".join(valid_fields)}\33[0m\n"
+
+        print("\n" + help_text)
+        while current_input != '':
+            current_input = self._get_user_input(f"Enter ({page}/{total})")
+
+            if current_input.casefold() == "h":  # print help text
+                print(help_text)
+
+            elif current_input.casefold() == "r":
+                self._open_sites_for_items(items=items, fields=self.fields)
+
+            elif current_input != "":
+                try:
+                    fields = [
+                        enum for field in re.sub(r"^n ", "", current_input).split(" ")
+                        for enum in Fields.from_name(field)
+                    ]
+                except MusifyEnumError:
+                    self.logger.warning(
+                        "Some fields were not recognised. "
+                        f"Please only use one of the following fields: {", ".join(valid_fields)}"
+                    )
+                    continue
+                self._open_sites_for_items(
+                    items=not_queried if current_input.startswith("n ") else items, fields=fields
+                )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "urls": self.urls,
+            "fields": [field.name for field in self.fields],
+            "interval": self.interval,
+        }

--- a/musify/shared/core/object.py
+++ b/musify/shared/core/object.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import datetime
 import logging
 from abc import ABCMeta, abstractmethod
-from collections.abc import Collection, Mapping
+from collections.abc import Iterable, Collection, Mapping
 from copy import deepcopy
-from typing import Any, Self, Iterable
+from typing import Any, Self
 
 from musify.processors.base import Filter
 from musify.processors.filter import FilterDefinedList

--- a/musify/shared/handlers.py
+++ b/musify/shared/handlers.py
@@ -1,0 +1,104 @@
+"""
+All logging handlers specific to this package.
+"""
+
+import logging.handlers
+import os
+import shutil
+from datetime import datetime
+from glob import glob
+from os.path import join, dirname, isfile, sep, isdir
+
+from musify.processors.time import TimeMapper
+from musify.shared.logger import LOGGING_DT_FORMAT
+
+
+###########################################################################
+## Logging handlers
+###########################################################################
+class CurrentTimeRotatingFileHandler(logging.handlers.BaseRotatingHandler):
+    """
+    Handles log file and directory rotation based on log file/folder name.
+
+    :param filename: The full path to the log file.
+        Optionally, include a '{}' part in the path to format in the current datetime.
+        When None, defaults to '{}.log'
+    :param encoding: When not None, it is used to open the file with that encoding.
+    :param when: The timespan for 'interval' which is used together to calculate the timedelta.
+        Accepts same values as :py:class:`TimeMapper`.
+    :param interval: The multiplier for ``when``.
+        When combined with ``when``, gives the negative timedelta relative to now
+        which is the maximum datetime to keep logs for.
+    :param count: The maximum number of files to keep.
+    :param delay: When True, the file opening is deferred until the first call to emit().
+    :param errors: Used to determine how encoding errors are handled.
+    """
+    def __init__(
+            self,
+            filename: str | None = None,
+            encoding: str | None = None,
+            when: str | None = None,
+            interval: int | None = None,
+            count: int | None = None,
+            delay: bool = False,
+            errors: str | None = None
+    ):
+        self.dt = datetime.now()
+
+        dt_str = self.dt.strftime(LOGGING_DT_FORMAT)
+        if not filename:
+            filename = "{}.log"
+        filename = filename.replace("\\", sep) if sep == "/" else filename.replace("/", sep)
+        self.filename = filename.format(dt_str) if "{}" in filename else filename
+        if dirname(self.filename):
+            os.makedirs(dirname(self.filename), exist_ok=True)
+
+        self.delta = TimeMapper(when.lower())(interval) if when and interval else None
+        self.count = count
+
+        self.removed: list[datetime] = []  # datetime on the files that were removed
+        self.rotator(unformatted=filename, formatted=self.filename)
+
+        super().__init__(filename=self.filename, mode="w", encoding=encoding, delay=delay, errors=errors)
+
+    # noinspection PyPep8Naming
+    @staticmethod
+    def shouldRollover(*_, **__) -> bool:
+        """Always returns False. Rotation happens on __init__ and only needs to happen once."""
+        return False
+
+    def rotator(self, unformatted: str, formatted: str):
+        """
+        Rotates the files in the folder on the given ``unformatted`` path.
+        Removes files older than ``self.delta`` and the oldest files when number of files >= count
+        until number of files <= count. ``formatted`` path is excluded from processing.
+        """
+        folder = dirname(formatted)
+        if not folder:
+            return
+
+        # get current files present and prefix+suffix to remove when processing
+        paths = tuple(f for f in glob(join(folder, "*")) if f != formatted)
+        prefix = unformatted.split("{")[0] if "{" in unformatted and "}" in unformatted else ""
+        suffix = unformatted.split("}")[1] if "{" in unformatted and "}" in unformatted else ""
+
+        remaining = len(paths)
+        for path in sorted(paths):
+            too_many = self.count is not None and remaining >= self.count
+
+            dt_part = path.removeprefix(prefix).removesuffix(suffix)
+            try:
+                dt_file = datetime.strptime(dt_part, LOGGING_DT_FORMAT)
+                too_old = self.delta is not None and dt_file < self.dt - self.delta
+            except ValueError:
+                dt_file = None
+                too_old = False
+
+            is_empty = isdir(path) and not glob(join(path, "*"))
+
+            if too_many or too_old or is_empty:
+                os.remove(path) if isfile(path) else shutil.rmtree(path)
+                remaining -= 1
+
+                if dt_file and dt_file not in self.removed:
+                    self.removed.append(dt_file)

--- a/musify/shared/logger.py
+++ b/musify/shared/logger.py
@@ -1,5 +1,5 @@
 """
-All classes and operations relating to logging for the entire package.
+All classes and operations (apart from handlers) relating to loggers for the entire package.
 """
 
 import inspect
@@ -8,18 +8,14 @@ import logging.config
 import logging.handlers
 import os
 import re
-import shutil
 from collections.abc import Iterable
-from datetime import datetime
-from glob import glob
-from os.path import join, dirname, splitext, split, basename, isfile, sep, isdir
+from os.path import join, splitext, split, basename
 from typing import Any
 
 import sys
 from tqdm.auto import tqdm
 
 from musify import PROGRAM_NAME
-from musify.processors.time import TimeMapper
 
 LOGGING_DT_FORMAT = "%Y-%m-%d_%H.%M.%S"
 
@@ -227,94 +223,3 @@ class LogFileFilter(logging.Filter):
         record.msg = re.sub("\33.*?m", "", record.msg)
         format_full_func_name(record, width=self.module_width)
         return record
-
-
-###########################################################################
-## Logging handlers
-###########################################################################
-class CurrentTimeRotatingFileHandler(logging.handlers.BaseRotatingHandler):
-    """
-    Handles log file and directory rotation based on log file/folder name.
-
-    :param filename: The full path to the log file.
-        Optionally, include a '{}' part in the path to format in the current datetime.
-        When None, defaults to '{}.log'
-    :param encoding: When not None, it is used to open the file with that encoding.
-    :param when: The timespan for 'interval' which is used together to calculate the timedelta.
-        Accepts same values as :py:class:`TimeMapper`.
-    :param interval: The multiplier for ``when``.
-        When combined with ``when``, gives the negative timedelta relative to now
-        which is the maximum datetime to keep logs for.
-    :param count: The maximum number of files to keep.
-    :param delay: When True, the file opening is deferred until the first call to emit().
-    :param errors: Used to determine how encoding errors are handled.
-    """
-    def __init__(
-            self,
-            filename: str | None = None,
-            encoding: str | None = None,
-            when: str | None = None,
-            interval: int | None = None,
-            count: int | None = None,
-            delay: bool = False,
-            errors: str | None = None
-    ):
-        self.dt = datetime.now()
-
-        dt_str = self.dt.strftime(LOGGING_DT_FORMAT)
-        if not filename:
-            filename = "{}.log"
-        filename = filename.replace("\\", sep) if sep == "/" else filename.replace("/", sep)
-        self.filename = filename.format(dt_str) if "{}" in filename else filename
-        if dirname(self.filename):
-            os.makedirs(dirname(self.filename), exist_ok=True)
-
-        self.delta = TimeMapper(when.lower())(interval) if when and interval else None
-        self.count = count
-
-        self.removed: list[datetime] = []  # datetime on the files that were removed
-        self.rotator(unformatted=filename, formatted=self.filename)
-
-        super().__init__(filename=self.filename, mode="w", encoding=encoding, delay=delay, errors=errors)
-
-    # noinspection PyPep8Naming
-    @staticmethod
-    def shouldRollover(*_, **__) -> bool:
-        """Always returns False. Rotation happens on __init__ and only needs to happen once."""
-        return False
-
-    def rotator(self, unformatted: str, formatted: str):
-        """
-        Rotates the files in the folder on the given ``unformatted`` path.
-        Removes files older than ``self.delta`` and the oldest files when number of files >= count
-        until number of files <= count. ``formatted`` path is excluded from processing.
-        """
-        folder = dirname(formatted)
-        if not folder:
-            return
-
-        # get current files present and prefix+suffix to remove when processing
-        paths = tuple(f for f in glob(join(folder, "*")) if f != formatted)
-        prefix = unformatted.split("{")[0] if "{" in unformatted and "}" in unformatted else ""
-        suffix = unformatted.split("}")[1] if "{" in unformatted and "}" in unformatted else ""
-
-        remaining = len(paths)
-        for path in sorted(paths):
-            too_many = self.count is not None and remaining >= self.count
-
-            dt_part = path.removeprefix(prefix).removesuffix(suffix)
-            try:
-                dt_file = datetime.strptime(dt_part, LOGGING_DT_FORMAT)
-                too_old = self.delta is not None and dt_file < self.dt - self.delta
-            except ValueError:
-                dt_file = None
-                too_old = False
-
-            is_empty = isdir(path) and not glob(join(path, "*"))
-
-            if too_many or too_old or is_empty:
-                os.remove(path) if isfile(path) else shutil.rmtree(path)
-                remaining -= 1
-
-                if dt_file and dt_file not in self.removed:
-                    self.removed.append(dt_file)

--- a/musify/shared/remote/processors/check.py
+++ b/musify/shared/remote/processors/check.py
@@ -263,7 +263,7 @@ class RemoteItemChecker(RemoteDataWrangler, ItemMatcher, InputProcessor, metacla
             pl_names = [name for name in self._playlist_name_collection if current_input.casefold() in name.casefold()]
 
             if current_input.casefold() == "h":  # print help text
-                print(help_text)
+                print("\n" + help_text)
 
             elif current_input.casefold() == 's' or current_input.casefold() == 'q':  # quit/skip
                 self._quit = current_input.casefold() == 'q' or self._quit

--- a/musify/shared/remote/processors/check.py
+++ b/musify/shared/remote/processors/check.py
@@ -8,10 +8,11 @@ reviewing matches through temporary playlist creation.
 import traceback
 from abc import ABCMeta, abstractmethod
 from collections import Counter
-from collections.abc import Mapping, Sequence, MutableSequence, Collection
+from collections.abc import Sequence, Collection
 from dataclasses import dataclass, field
 
 from musify import PROGRAM_NAME
+from musify.processors.base import InputProcessor
 from musify.processors.match import ItemMatcher
 from musify.shared.core.base import Item
 from musify.shared.core.collection import ItemCollection
@@ -24,7 +25,7 @@ from musify.shared.remote.config import RemoteObjectClasses
 from musify.shared.remote.enum import RemoteObjectType, RemoteIDType
 from musify.shared.remote.processors.search import RemoteItemSearcher
 from musify.shared.remote.processors.wrangle import RemoteDataWrangler
-from musify.shared.utils import get_user_input, get_max_width, align_and_truncate
+from musify.shared.utils import get_max_width, align_and_truncate
 
 ALLOW_KARAOKE_DEFAULT = RemoteItemSearcher.settings_items.allow_karaoke
 
@@ -40,7 +41,7 @@ class ItemCheckResult(Result):
     skipped: Sequence[Item] = field(default=tuple())
 
 
-class RemoteItemChecker(RemoteDataWrangler, ItemMatcher, metaclass=ABCMeta):
+class RemoteItemChecker(RemoteDataWrangler, ItemMatcher, InputProcessor, metaclass=ABCMeta):
     """
     Runs operations for checking the URIs associated with a collection of items.
 
@@ -112,25 +113,6 @@ class RemoteItemChecker(RemoteDataWrangler, ItemMatcher, metaclass=ABCMeta):
         self._final_unavailable: list[Track] = []
         #: The final list of items skipped by the checker
         self._final_skipped: list[Track] = []
-
-    def _get_user_input(self, text: str | None = None) -> str:
-        """Print dialog with optional text and get the user's input."""
-        inp = get_user_input(text)
-        self.logger.debug(f"User input: {inp}")
-        return inp.strip()
-
-    @staticmethod
-    def _format_help_text(options: Mapping[str, str], header: MutableSequence[str] | None = None) -> str:
-        """Format help text with a given mapping of options. Add an option header to include before options."""
-        max_width = get_max_width(options)
-
-        help_text = header or []
-        help_text.append("\n\t\33[96mEnter one of the following: \33[0m\n\t")
-        help_text.extend(
-            f"{align_and_truncate(k, max_width=max_width)}{': ' + v or ''}" for k, v in options.items()
-        )
-
-        return "\n\t".join(help_text) + '\n'
 
     def _check_api(self):
         """Check if the API token has expired and refresh as necessary"""
@@ -257,7 +239,7 @@ class RemoteItemChecker(RemoteDataWrangler, ItemMatcher, metaclass=ABCMeta):
         :param total: The total number of pages (pauses) that will occur in this run.
         """
         header = [
-            f"\n\t\33[1;94mTemporary playlists created on {self.source}.",
+            f"\t\33[1;94mTemporary playlists created on {self.source}.",
             f"You may now check the songs in each playlist on {self.source}. \33[0m"
         ]
         options = {
@@ -280,16 +262,13 @@ class RemoteItemChecker(RemoteDataWrangler, ItemMatcher, metaclass=ABCMeta):
             current_input = self._get_user_input(f"Enter ({page}/{total})")
             pl_names = [name for name in self._playlist_name_collection if current_input.casefold() in name.casefold()]
 
-            if current_input == "":  # user entered no option, break loop and return
-                break
+            if current_input.casefold() == "h":  # print help text
+                print(help_text)
 
             elif current_input.casefold() == 's' or current_input.casefold() == 'q':  # quit/skip
                 self._quit = current_input.casefold() == 'q' or self._quit
                 self._skip = current_input.casefold() == 's' or self._skip
                 break
-
-            elif current_input.casefold() == "h":  # print help text
-                print(help_text)
 
             elif pl_names:  # print originally added items
                 name = pl_names[0]
@@ -308,7 +287,7 @@ class RemoteItemChecker(RemoteDataWrangler, ItemMatcher, metaclass=ABCMeta):
                 self._check_api()
                 self.api.print_collection(current_input)
 
-            else:
+            elif current_input != "":
                 self.logger.warning("Input not recognised.")
 
     ###########################################################################
@@ -439,7 +418,17 @@ class RemoteItemChecker(RemoteDataWrangler, ItemMatcher, metaclass=ABCMeta):
                 if 'a' not in current_input:
                     current_input = self._get_user_input(align_and_truncate(item.name, max_width=max_width))
 
-                if current_input.casefold().replace('a', '') == 'u':  # mark item as unavailable
+                if current_input.casefold() == 'h':  # print help
+                    print("\n" + help_text)
+
+                elif current_input.casefold() == 's' or current_input.casefold() == 'q':  # quit/skip
+                    self._log_padded([name, "Skipping all loops"], pad="<")
+                    self._quit = current_input.casefold() == 'q' or self._quit
+                    self._skip = current_input.casefold() == 's' or self._skip
+                    self._remaining.clear()
+                    return
+
+                elif current_input.casefold().replace('a', '') == 'u':  # mark item as unavailable
                     self._log_padded([name, "Marking as unavailable"], pad="<")
                     item.uri = self.unavailable_uri_dummy
                     self._remaining.remove(item)
@@ -452,16 +441,6 @@ class RemoteItemChecker(RemoteDataWrangler, ItemMatcher, metaclass=ABCMeta):
                 elif current_input.casefold() == 'r':  # return to former 'while' loop
                     self._log_padded([name, "Refreshing playlist metadata and restarting loop"])
                     return
-
-                elif current_input.casefold() == 's' or current_input.casefold() == 'q':  # quit/skip
-                    self._log_padded([name, "Skipping all loops"], pad="<")
-                    self._quit = current_input.casefold() == 'q' or self._quit
-                    self._skip = current_input.casefold() == 's' or self._skip
-                    self._remaining.clear()
-                    return
-
-                elif current_input.casefold() == 'h':  # print help
-                    print("\n" + help_text)
 
                 elif current_input.casefold() == 'p' and hasattr(item, "path"):  # print item path
                     print(f"\33[96m{item.path}\33[0m")

--- a/musify/spotify/api/api.py
+++ b/musify/spotify/api/api.py
@@ -9,6 +9,7 @@ from collections.abc import Iterable
 from copy import deepcopy
 
 from musify import PROGRAM_NAME
+from musify.shared.api.exception import APIError
 from musify.shared.utils import safe_format_map
 from musify.spotify import URL_API, URL_AUTH
 from musify.spotify.api.item import SpotifyAPIItems
@@ -78,14 +79,20 @@ class SpotifyAPI(SpotifyAPIMisc, SpotifyAPIItems, SpotifyAPIPlaylists):
     def user_id(self) -> str | None:
         """ID of the currently authenticated user"""
         if not self.user_data:
-            self.user_data = self.get_self()
+            try:
+                self.user_data = self.get_self()
+            except APIError:
+                return None
         return self.user_data["id"]
 
     @property
     def user_name(self) -> str | None:
         """Name of the currently authenticated user"""
         if not self.user_data:
-            self.user_data = self.get_self()
+            try:
+                self.user_data = self.get_self()
+            except APIError:
+                return None
         return self.user_data["display_name"]
 
     def __init__(

--- a/tests/__resources/test_logging.yml
+++ b/tests/__resources/test_logging.yml
@@ -43,7 +43,7 @@ handlers:
     level: INFO_EXTRA
 
   file:
-    class: musify.shared.logger.CurrentTimeRotatingFileHandler
+    class: musify.shared.handlers.CurrentTimeRotatingFileHandler
     level: DEBUG
     formatter: extended
     filters: ["file"]
@@ -57,7 +57,7 @@ handlers:
 loggers:
   test:  &logger
     level: DEBUG
-    handlers: [console_info, file]
+    handlers: [console_info]
     propagate: no
 
   dev:

--- a/tests/processors/test_base.py
+++ b/tests/processors/test_base.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from musify.processors.base import DynamicProcessor, dynamicprocessormethod
 
 
@@ -34,6 +36,9 @@ class TestDynamicProcessor(DynamicProcessor):
     @dynamicprocessormethod("processor_3_alternative", "processor_extra")
     def processor_3(self):
         return 3
+
+    def as_dict(self) -> dict[str, Any]:
+        return {}
 
 
 def test_dynamic_processor():

--- a/tests/processors/test_download.py
+++ b/tests/processors/test_download.py
@@ -1,0 +1,140 @@
+from copy import copy
+from random import sample, randrange
+
+import pytest
+from pytest_mock import MockerFixture
+
+from musify import MODULE_ROOT
+from musify.local.track import LocalTrack
+from musify.shared.core.enum import Fields
+from musify.shared.core.object import BasicCollection
+from musify.processors.download import ItemDownloadHelper
+from tests.local.track.utils import random_tracks
+from tests.shared.core.misc import PrettyPrinterTester
+from tests.shared.remote.processors.utils import patch_input
+from tests.utils import random_str, get_stdout
+
+
+class TestItemDownloadHelper(PrettyPrinterTester):
+    """Run generic tests for :py:class:`RemoteItemDownloadHelper` implementations."""
+
+    @pytest.fixture
+    def obj(self, download_helper: ItemDownloadHelper) -> ItemDownloadHelper:
+        return download_helper
+
+    @pytest.fixture
+    def download_helper(self) -> ItemDownloadHelper:
+        """Yields a valid :py:class:`RemoteItemDownloadHelper` for the current remote source as a pytest.fixture."""
+        sites = [
+            "https://bandcamp.com/search?q={}&item_type=t",
+            "https://uk.7digital.com/search?q={}&f=9%2C2",
+            "https://www.junodownload.com/search/?q%5Ball%5D%5B%5D={}&solrorder=relevancy",
+            "https://www.jamendo.com/search?q={}",
+            "https://www.amazon.com/s?k={}&i=digital-music",
+            "https://www.google.com/search?q={}%20mp3",
+        ]
+        return ItemDownloadHelper(
+            urls=sample(sites, k=randrange(2, len(sites))),
+            fields=Fields.ALL,
+            interval=1,
+        )
+
+    @pytest.fixture
+    def collections(self) -> list[BasicCollection[LocalTrack]]:
+        """Yields many valid :py:class:`BasicCollection` of :py:class:`RemoteItem` as a pytest.fixture."""
+        return [BasicCollection(name=random_str(30, 50), items=random_tracks()) for _ in range(randrange(3, 10))]
+
+    @staticmethod
+    def test_valid_setup(download_helper: ItemDownloadHelper, collections: list[BasicCollection]):
+        assert len(download_helper.urls) > 1
+        assert Fields.ALL in download_helper.fields or len(download_helper.fields) > 2
+
+        assert sum(len(coll.items) for coll in collections) > 3
+
+    @staticmethod
+    def test_opened_urls(
+            download_helper: ItemDownloadHelper,
+            collections: list[BasicCollection],
+            mocker: MockerFixture,
+    ):
+        def log_urls(url) -> None:
+            """Log the opened URLs"""
+            nonlocal urls
+            urls.append(url)
+
+        urls = []
+        mocker.patch(f"{MODULE_ROOT}.processors.download.webopen", new=log_urls)
+
+        patch_input(values=[""] * sum(len(coll.items) for coll in collections), mocker=mocker)
+
+        download_helper.open_sites(collections)
+        mocker.stopall()
+
+        assert len(urls) == sum(len(coll.items) for coll in collections) * len(download_helper.urls)
+
+    @staticmethod
+    def test_pause_1(
+            download_helper: ItemDownloadHelper,
+            collections: list[BasicCollection],
+            mocker: MockerFixture,
+            capfd: pytest.CaptureFixture,
+    ):
+        def log_urls(url) -> None:
+            """Log the opened URLs"""
+            nonlocal urls
+            urls.append(url)
+
+        urls = []
+        mocker.patch(f"{MODULE_ROOT}.processors.download.webopen", new=log_urls)
+
+        total = sum(len(coll.items) for coll in collections)
+        pages_total = (total // download_helper.interval) + (total % download_helper.interval > 0)
+        patch_input(values=["r", "", "title artist", "r", "title bad_tag", ""] + [""] * total, mocker=mocker)
+
+        download_helper.open_sites(collections)
+        mocker.stopall()
+        capfd.close()
+
+        # 3 extra for 2*r input + 1*<Fields> input
+        assert len(urls) == (total + 3) * len(download_helper.urls)
+
+        stdout = get_stdout(capfd)  # removes colour codes
+        assert stdout.count("Enter one of the following") == pages_total
+        assert stdout.count("Some fields were not recognised") == 1
+
+    @staticmethod
+    def test_pause_2(
+            download_helper: ItemDownloadHelper,
+            collections: list[BasicCollection[LocalTrack]],
+            mocker: MockerFixture,
+            capfd: pytest.CaptureFixture,
+    ):
+        def log_urls(url) -> None:
+            """Log the opened URLs"""
+            nonlocal urls
+            urls.append(url)
+
+        urls = []
+        mocker.patch(f"{MODULE_ROOT}.processors.download.webopen", new=log_urls)
+
+        # force a few poison apples
+        test_items = [copy(item) for coll in collections for item in coll][:10]
+        for item in sample(test_items, k=3):
+            item.artist = None
+            item.album = None
+
+        download_helper.fields = [Fields.ARTIST, Fields.ALBUM]
+        download_helper.interval = len(test_items)
+
+        patch_input(values=["h", "artist", "h", "n title", "h", "", "h", "h"], mocker=mocker)
+
+        download_helper.open_sites(BasicCollection(name="test", items=test_items))
+        mocker.stopall()
+        capfd.close()
+
+        # 3 extra for 2*r input + 1*<Fields> input
+        assert len(urls) == (2 * len(test_items) - 3) * len(download_helper.urls)
+
+        stdout = get_stdout(capfd)  # removes colour codes
+        assert stdout.count("Enter one of the following") == 4
+        assert "Some fields were not recognised" not in stdout

--- a/tests/shared/remote/processors/search.py
+++ b/tests/shared/remote/processors/search.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Iterable
 from copy import copy
 from urllib.parse import parse_qs
@@ -14,11 +14,16 @@ from musify.shared.core.object import BasicCollection, Album
 from musify.shared.remote.enum import RemoteObjectType
 from musify.shared.remote.processors.search import RemoteItemSearcher, SearchSettings
 from tests.local.track.utils import random_track, random_tracks
+from tests.shared.core.misc import PrettyPrinterTester
 from tests.shared.remote.utils import RemoteMock
 
 
-class RemoteItemSearcherTester(ABC):
+class RemoteItemSearcherTester(PrettyPrinterTester, metaclass=ABCMeta):
     """Run generic tests for :py:class:`RemoteItemSearcher` implementations."""
+
+    @pytest.fixture
+    def obj(self, searcher: RemoteItemSearcher) -> RemoteItemSearcher:
+        return searcher
 
     @abstractmethod
     def searcher(self, *args, **kwargs) -> RemoteItemSearcher:

--- a/tests/shared/remote/processors/utils.py
+++ b/tests/shared/remote/processors/utils.py
@@ -1,0 +1,10 @@
+from pytest_mock import MockerFixture
+
+
+def patch_input(values: list[str], mocker: MockerFixture) -> None:
+    """``builtins.input`` calls will return the ``values`` in order, finishing on ''"""
+    def input_return(*_, **__) -> str:
+        """An order of return values for user input that will test various stages of the pause"""
+        return values.pop(0) if values else ""
+
+    mocker.patch('builtins.input', new=input_return)

--- a/tests/shared/test_handlers.py
+++ b/tests/shared/test_handlers.py
@@ -1,0 +1,105 @@
+import os
+import string
+from datetime import datetime, timedelta
+from glob import glob
+from os.path import join, basename, splitext
+from pathlib import Path
+from random import choice
+
+import pytest
+
+from musify.shared.logger import LOGGING_DT_FORMAT
+from musify.shared.handlers import CurrentTimeRotatingFileHandler
+from tests.utils import random_str
+
+
+###########################################################################
+## Logging handlers
+###########################################################################
+def test_current_time_file_handler_namer(tmp_path: Path):
+    # no filename given
+    handler = CurrentTimeRotatingFileHandler(delay=True)
+    assert handler.filename == handler.dt.strftime(LOGGING_DT_FORMAT) + ".log"
+
+    # no format part given
+    handler = CurrentTimeRotatingFileHandler(filename="test.log", delay=True)
+    assert handler.filename == "test.log"
+
+    # filename with format part given and fixes separators
+    sep = "\\" if os.path.sep == "/" else "/"
+    base_parts = [*str(tmp_path).split(os.path.sep), "folder", "file_{}_suffix.log"]
+    base_str = sep.join(base_parts)
+
+    handler = CurrentTimeRotatingFileHandler(filename=base_str, delay=True)
+    assert handler.filename == os.path.sep.join(base_parts).format(handler.dt.strftime(LOGGING_DT_FORMAT))
+
+    base_parts[-1] = base_parts[-1].format(handler.dt.strftime(LOGGING_DT_FORMAT))
+    assert sep not in handler.filename
+    assert handler.filename.split(os.path.sep) == base_parts
+
+
+@pytest.fixture
+def log_paths(tmp_path: Path) -> list[str]:
+    """Generate a set of log files and return their paths"""
+    dt_now = datetime.now()
+
+    paths = []
+    for i in range(1, 50, 2):
+        dt_str = (dt_now - timedelta(hours=i)).strftime(LOGGING_DT_FORMAT)
+        path = join(tmp_path, dt_str + ".log")
+        paths.append(path)
+
+        with open(path, 'w') as f:
+            for _ in range(600):
+                f.write(choice(string.ascii_letters))
+
+    return paths
+
+
+def test_current_time_file_handler_rotator_time(log_paths: list[str], tmp_path: Path):
+    handler = CurrentTimeRotatingFileHandler(filename=join(tmp_path, "{}.log"), when="h", interval=10)
+
+    for dt in handler.removed:
+        assert dt < handler.dt - timedelta(hours=10)
+    for path in glob(join(tmp_path, "*")):
+        dt = datetime.strptime(splitext(basename(path))[0], LOGGING_DT_FORMAT)
+        assert dt >= handler.dt - timedelta(hours=10)
+
+
+def test_current_time_file_handler_rotator_count(log_paths: list[str], tmp_path: Path):
+    CurrentTimeRotatingFileHandler(filename=join(tmp_path, "{}.log"), count=10)
+    assert len(glob(join(tmp_path, "*"))) == 10
+
+
+def test_current_time_file_handler_rotator_combined(log_paths: list[str], tmp_path: Path):
+    handler = CurrentTimeRotatingFileHandler(filename=join(tmp_path, "{}.log"), when="h", interval=10, count=3)
+
+    for path in glob(join(tmp_path, "*")):
+        dt = datetime.strptime(splitext(basename(path))[0], LOGGING_DT_FORMAT)
+        assert dt >= handler.dt - timedelta(hours=10)
+
+    assert len(glob(join(tmp_path, "*"))) <= 3
+
+
+def test_current_time_file_handler_rotator_folders(tmp_path: Path):
+    dt_now = datetime.now()
+
+    paths = []
+    for i in range(1, 50, 2):
+        dt_str = (dt_now - timedelta(hours=i)).strftime(LOGGING_DT_FORMAT)
+        path = join(tmp_path, dt_str)
+        paths.append(path)
+        os.makedirs(path)
+
+        if i > 10:  # all folders with dt >10hrs will be empty
+            continue
+
+        with open(join(path, random_str() + ".txt"), 'w') as f:
+            for _ in range(600):
+                f.write(choice(string.ascii_letters))
+
+    handler = CurrentTimeRotatingFileHandler(filename=join(tmp_path, "{}"), when="h", interval=20)
+
+    for path in glob(join(tmp_path, "*")):
+        dt = datetime.strptime(basename(path), LOGGING_DT_FORMAT)
+        assert dt >= handler.dt - timedelta(hours=10)  # deleted all empty folders >10hrs

--- a/tests/shared/test_logger.py
+++ b/tests/shared/test_logger.py
@@ -1,19 +1,12 @@
 import logging
-import os
-import string
 from copy import copy, deepcopy
-from datetime import datetime, timedelta
-from glob import glob
-from os.path import join, basename, splitext
-from pathlib import Path
-from random import choice
+from os.path import basename
 
 import pytest
 import sys
 
-from musify.shared.logger import MusifyLogger, INFO_EXTRA, REPORT, STAT, LOGGING_DT_FORMAT
-from musify.shared.logger import format_full_func_name, LogFileFilter, CurrentTimeRotatingFileHandler
-from tests.utils import random_str
+from musify.shared.logger import MusifyLogger, INFO_EXTRA, REPORT, STAT
+from musify.shared.logger import format_full_func_name, LogFileFilter
 
 
 ###########################################################################
@@ -195,95 +188,3 @@ def test_file_filter():
     record.msg = "\33[91;1mcolour \33[94;0mmessage\33[0m"
     log_filter.filter(record)
     assert record.msg == "colour message"
-
-
-###########################################################################
-## Logging handlers
-###########################################################################
-def test_current_time_file_handler_namer(tmp_path: Path):
-    # no filename given
-    handler = CurrentTimeRotatingFileHandler(delay=True)
-    assert handler.filename == handler.dt.strftime(LOGGING_DT_FORMAT) + ".log"
-
-    # no format part given
-    handler = CurrentTimeRotatingFileHandler(filename="test.log", delay=True)
-    assert handler.filename == "test.log"
-
-    # filename with format part given and fixes separators
-    sep = "\\" if os.path.sep == "/" else "/"
-    base_parts = [*str(tmp_path).split(os.path.sep), "folder", "file_{}_suffix.log"]
-    base_str = sep.join(base_parts)
-
-    handler = CurrentTimeRotatingFileHandler(filename=base_str, delay=True)
-    assert handler.filename == os.path.sep.join(base_parts).format(handler.dt.strftime(LOGGING_DT_FORMAT))
-
-    base_parts[-1] = base_parts[-1].format(handler.dt.strftime(LOGGING_DT_FORMAT))
-    assert sep not in handler.filename
-    assert handler.filename.split(os.path.sep) == base_parts
-
-
-@pytest.fixture
-def log_paths(tmp_path: Path) -> list[str]:
-    """Generate a set of log files and return their paths"""
-    dt_now = datetime.now()
-
-    paths = []
-    for i in range(1, 50, 2):
-        dt_str = (dt_now - timedelta(hours=i)).strftime(LOGGING_DT_FORMAT)
-        path = join(tmp_path, dt_str + ".log")
-        paths.append(path)
-
-        with open(path, 'w') as f:
-            for _ in range(600):
-                f.write(choice(string.ascii_letters))
-
-    return paths
-
-
-def test_current_time_file_handler_rotator_time(log_paths: list[str], tmp_path: Path):
-    handler = CurrentTimeRotatingFileHandler(filename=join(tmp_path, "{}.log"), when="h", interval=10)
-
-    for dt in handler.removed:
-        assert dt < handler.dt - timedelta(hours=10)
-    for path in glob(join(tmp_path, "*")):
-        dt = datetime.strptime(splitext(basename(path))[0], LOGGING_DT_FORMAT)
-        assert dt >= handler.dt - timedelta(hours=10)
-
-
-def test_current_time_file_handler_rotator_count(log_paths: list[str], tmp_path: Path):
-    CurrentTimeRotatingFileHandler(filename=join(tmp_path, "{}.log"), count=10)
-    assert len(glob(join(tmp_path, "*"))) == 10
-
-
-def test_current_time_file_handler_rotator_combined(log_paths: list[str], tmp_path: Path):
-    handler = CurrentTimeRotatingFileHandler(filename=join(tmp_path, "{}.log"), when="h", interval=10, count=3)
-
-    for path in glob(join(tmp_path, "*")):
-        dt = datetime.strptime(splitext(basename(path))[0], LOGGING_DT_FORMAT)
-        assert dt >= handler.dt - timedelta(hours=10)
-
-    assert len(glob(join(tmp_path, "*"))) <= 3
-
-
-def test_current_time_file_handler_rotator_folders(tmp_path: Path):
-    dt_now = datetime.now()
-
-    paths = []
-    for i in range(1, 50, 2):
-        dt_str = (dt_now - timedelta(hours=i)).strftime(LOGGING_DT_FORMAT)
-        path = join(tmp_path, dt_str)
-        paths.append(path)
-        os.makedirs(path)
-
-        if i > 10:  # all folders with dt >10hrs will be empty
-            continue
-
-        with open(join(path, random_str() + ".txt"), 'w') as f:
-            for _ in range(600):
-                f.write(choice(string.ascii_letters))
-
-    handler = CurrentTimeRotatingFileHandler(filename=join(tmp_path, "{}"), when="h", interval=20)
-
-    for path in glob(join(tmp_path, "*")):
-        dt = datetime.strptime(basename(path), LOGGING_DT_FORMAT)
-        assert dt >= handler.dt - timedelta(hours=10)  # deleted all empty folders >10hrs


### PR DESCRIPTION
Added
-----
* Add the ItemDownloadHelper general processor

Changed
-------
* Factor out logging handlers to their own script to avoid circular import issues
* Abstract away input methods of RemoteItemChecker to InputProcessor base class
* Factor out patch_input method to function in InputProcessor derived tests

Fixed
-----
* Captured stdout assertions in RemoteItemChecker tests re-enabled, now fixed
* Surround RemoteApi 'user' properties in try-except block so they can still be
  pretty printed even if API is not authorised

Documentation
-------------
* Fix redirect/broken links
* Change notes text to proper rst syntax