### PR TITLE
Fix non-random data issue in Spotify tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,8 @@ build = [
 test = [
     "pytest~=8.0",
     "pytest-mock~=3.12",
-    "pytest-repeat~=0.9",
-    "pycountry~=23.12",
     "requests-mock~=1.11",
+    "pycountry~=23.12",
 ]
 docs = [
     "musify[build]",

--- a/scripts/pytest_repeat.bat
+++ b/scripts/pytest_repeat.bat
@@ -1,0 +1,25 @@
+set COUNTER=0
+
+echo "Executing %2 repetitions for tests: %1"
+
+:repeat
+set /A COUNTER=COUNTER+1
+echo "Executing repetition: %COUNTER%"
+
+pytest %1 || goto :fail
+
+if %COUNTER% == %2 (
+   goto :pass
+) else (
+   goto :repeat
+)
+
+:pass
+rundll32 user32.dll,MessageBeep
+msg console /time:3600 "All tests passed successfully after %COUNTER% runs"
+exit /B 0
+
+:fail
+rundll32 user32.dll,MessageBeep
+msg console /time:3600 "Tests failed after %COUNTER% runs"
+exit /B 1

--- a/tests/spotify/api/mock.py
+++ b/tests/spotify/api/mock.py
@@ -707,6 +707,7 @@ class SpotifyMock(RemoteMock):
             item_count: int | None = None,
             owner: str | dict[str, Any] | None = None,
             api: SpotifyAPI | None = None,
+            use_stored: bool = True,
     ) -> dict[str, Any]:
         """
         Return a randomly generated Spotify API response for a Playlist.
@@ -718,6 +719,7 @@ class SpotifyMock(RemoteMock):
         :param api: An optional, authenticated :py:class:`SpotifyAPI` object to extract user information from.
             This will be used to generate an owner block to playlist when ``owner`` is None.
             Has priority over ``owner`` when ``owner`` is a string.
+        :param use_stored: When True, add stored items to the playlist response instead of generating new ones.
         """
         kind = ObjectType.PLAYLIST.name.lower()
         playlist_id = random_id()
@@ -751,7 +753,7 @@ class SpotifyMock(RemoteMock):
             "uri": f"{SPOTIFY_NAME.lower()}:{kind}:{playlist_id}",
         }
 
-        tracks = self.generate_playlist_tracks(response=response)
+        tracks = self.generate_playlist_tracks(response=response, use_stored=use_stored)
         url = response["tracks"]["href"]
         response["tracks"] = self.format_items_block(url=url, items=tracks, limit=len(tracks), total=item_count)
 
@@ -797,7 +799,12 @@ class SpotifyMock(RemoteMock):
     ## Generators - ALBUM
     ###########################################################################
     def generate_album(
-            self, track_count: int | None = None, tracks: bool = True, artists: bool = True, properties: bool = True,
+            self,
+            track_count: int | None = None,
+            tracks: bool = True,
+            artists: bool = True,
+            properties: bool = True,
+            use_stored: bool = True,
     ) -> dict[str, Any]:
         """
         Return a randomly generated Spotify API response for an Album.
@@ -806,6 +813,7 @@ class SpotifyMock(RemoteMock):
         :param tracks: Add randomly generated tracks information to the response as per documentation.
         :param artists: Add randomly generated artists information to the response as per documentation.
         :param properties: Add extra randomly generated properties information to the response as per documentation.
+        :param use_stored: When True, add stored tracks to the playlist response instead of generating new ones.
         """
         kind = ObjectType.ALBUM.name.lower()
         album_id = random_id()
@@ -827,7 +835,7 @@ class SpotifyMock(RemoteMock):
         }
 
         if tracks:
-            tracks = self.generate_album_tracks(response=response)
+            tracks = self.generate_album_tracks(response=response, use_stored=use_stored)
             url = response["href"] + "/tracks"
             response["tracks"] = self.format_items_block(url=url, items=tracks, limit=len(tracks), total=track_count)
 

--- a/tests/spotify/test_spotify_collection.py
+++ b/tests/spotify/test_spotify_collection.py
@@ -35,7 +35,7 @@ class TestSpotifyAlbum(SpotifyCollectionLoaderTester):
     @pytest.fixture
     def response_random(self, api_mock: SpotifyMock) -> dict[str, Any]:
         """Yield a randomly generated response from the Spotify API for a track item type"""
-        response = api_mock.generate_album(track_count=10)
+        response = api_mock.generate_album(track_count=10, use_stored=False)
         response["total_tracks"] = len(response["tracks"]["items"])
         response["tracks"]["total"] = len(response["tracks"]["items"])
         response["tracks"]["next"] = None
@@ -260,7 +260,10 @@ class TestSpotifyArtist(RemoteCollectionTester):
     def response_random(self, api_mock: SpotifyMock) -> dict[str, Any]:
         """Yield a randomly generated response from the Spotify API for an artist item type"""
         artist = api_mock.generate_artist()
-        albums = [api_mock.generate_album(tracks=False, artists=False) for _ in range(randrange(5, 10))]
+        albums = [
+            api_mock.generate_album(tracks=False, artists=False, use_stored=False)
+            for _ in range(randrange(5, 10))
+        ]
         for album in albums:
             album["artists"] = [deepcopy(artist)]
             album["total_tracks"] = 0

--- a/tests/spotify/test_spotify_playlist.py
+++ b/tests/spotify/test_spotify_playlist.py
@@ -35,7 +35,7 @@ class TestSpotifyPlaylist(SpotifyCollectionLoaderTester, RemotePlaylistTester):
     @pytest.fixture
     def response_random(self, api_mock: SpotifyMock) -> dict[str, Any]:
         """Yield a randomly generated response from the Spotify API for a track item type"""
-        response = api_mock.generate_playlist(item_count=100)
+        response = api_mock.generate_playlist(item_count=100, use_stored=False)
         response["tracks"]["total"] = len(response["tracks"]["items"])
         response["tracks"]["next"] = None
         return response


### PR DESCRIPTION
Added use_stored option to generate mock spotify album/playlist functions and set this to `False` for random responses.

Motivation:
Some tests in the SpotifyPlaylist test suite were expecting random responses. These tests expect random responses to ensure that none of the generated test terack data overlapped with the tracks in the original playlist under test. It seems that sometimes, these random responses were actually returning track data for tracks already in the playlist under test. This should now fix the issue.