### PR TITLE
expand processor inputs

### DIFF
--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -39,6 +39,9 @@ Added
 -----
 
 * :py:class:`.RemoteAPI` methods now accept :py:class:`.RemoteResponse` objects as input, refreshing them automatically
+* Property 'kind' to all objects which have an associated :py:class:`.RemoteObjectType`
+* Introduced :py:class:`.MusifyItemSettable` class to allow distinction
+  between items that can have their properties set and those that can't
 
 Changed
 -------
@@ -51,6 +54,9 @@ Changed
 * :py:meth:`.SpotifyArtist.load` now uses the base `load` method from :py:class:`.SpotifyCollectionLoader`
   meaning it now takes full advantage of the item filtering this method offers.
   As part of this, the base method was made more generic to accommodate all :py:class:`.SpotifyObject` types
+* Renamed 'kind' property on :py:class:`.LocalTrack` to 'type' to avoid clashing property names
+* :py:class:`.ItemMatcher`, :py:class:`.RemoteItemChecker`, and :py:class:`.RemoteItemSearcher` now accept
+  all MusifyItem types that may have their URI property set manually.
 
 0.8.1
 =====

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -58,6 +58,11 @@ Changed
 * :py:class:`.ItemMatcher`, :py:class:`.RemoteItemChecker`, and :py:class:`.RemoteItemSearcher` now accept
   all MusifyItem types that may have their URI property set manually.
 
+Fixed
+-----
+
+* :py:class:`.Comparer` dynamic processor methods which process string values now cast expected types before processing
+
 0.8.1
 =====
 

--- a/musify/core/base.py
+++ b/musify/core/base.py
@@ -71,3 +71,20 @@ class MusifyItem(MusifyObject, Hashable, metaclass=ABCMeta):
     def __getitem__(self, key: str) -> Any:
         """Get the value of a given attribute key"""
         return getattr(self, key)
+
+
+# noinspection PyPropertyDefinition
+class MusifyItemSettable(MusifyItem, metaclass=ABCMeta):
+    """Generic class for storing an item that can have select properties modified."""
+
+    @abstractmethod
+    def _uri_getter(self) -> str | None:
+        """URI (Uniform Resource Indicator) is the unique identifier for this item."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _uri_setter(self, value: str | None):
+        """Set both the ``uri`` property and the ``has_uri`` property ."""
+        raise NotImplementedError
+
+    uri = property(lambda self: self._uri_getter(), lambda self, v: self._uri_setter(v))

--- a/musify/core/enum.py
+++ b/musify/core/enum.py
@@ -127,7 +127,7 @@ class Fields(Field):
     FILENAME = 3
     EXT = 100
     SIZE = 7
-    KIND = 4
+    TYPE = 4
     CHANNELS = 8
     BIT_RATE = 10
     BIT_DEPTH = 183
@@ -262,7 +262,7 @@ class TagFields(TagField):
     FILENAME = Fields.FILENAME.value
     EXT = Fields.EXT.value
     SIZE = Fields.SIZE.value
-    KIND = Fields.KIND.value
+    TYPE = Fields.TYPE.value
     CHANNELS = Fields.CHANNELS.value
     BIT_RATE = Fields.BIT_RATE.value
     BIT_DEPTH = Fields.BIT_DEPTH.value

--- a/musify/libraries/core/object.py
+++ b/musify/libraries/core/object.py
@@ -13,6 +13,7 @@ from typing import Any
 from musify.core.base import MusifyItem
 from musify.exception import MusifyTypeError
 from musify.libraries.core.collection import MusifyCollection
+from musify.libraries.remote.core.enum import RemoteObjectType
 from musify.libraries.remote.core.processors.wrangle import RemoteDataWrangler
 from musify.log.logger import MusifyLogger
 from musify.processors.base import Filter
@@ -24,6 +25,12 @@ class Track(MusifyItem, metaclass=ABCMeta):
     """Represents a track including its metadata/tags/properties."""
 
     __attributes_ignore__ = "name"
+
+    # noinspection PyPropertyDefinition
+    @classmethod
+    @property
+    def kind(cls):
+        return RemoteObjectType.TRACK
 
     @property
     def name(self) -> str:
@@ -169,6 +176,12 @@ class Playlist[T: Track](MusifyCollection[T], metaclass=ABCMeta):
 
     __attributes_classes__ = MusifyCollection
     __attributes_ignore__ = "items"
+
+    # noinspection PyPropertyDefinition
+    @classmethod
+    @property
+    def kind(cls):
+        return RemoteObjectType.PLAYLIST
 
     @property
     @abstractmethod
@@ -461,6 +474,12 @@ class Album[T: Track](MusifyCollection[T], metaclass=ABCMeta):
     __attributes_classes__ = MusifyCollection
     __attributes_ignore__ = ("name", "items")
 
+    # noinspection PyPropertyDefinition
+    @classmethod
+    @property
+    def kind(cls):
+        return RemoteObjectType.ALBUM
+
     @property
     @abstractmethod
     def name(self) -> str:
@@ -576,6 +595,12 @@ class Artist[T: Track](MusifyCollection[T], metaclass=ABCMeta):
 
     __attributes_classes__ = MusifyCollection
     __attributes_ignore__ = ("name", "items")
+
+    # noinspection PyPropertyDefinition
+    @classmethod
+    @property
+    def kind(cls):
+        return RemoteObjectType.ARTIST
 
     @property
     @abstractmethod

--- a/musify/libraries/local/base.py
+++ b/musify/libraries/local/base.py
@@ -3,11 +3,11 @@ Core abstract classes for the :py:mod:`Local` module.
 """
 from abc import ABCMeta
 
-from musify.core.base import MusifyItem
+from musify.core.base import MusifyItemSettable
 from musify.file.base import File
 
 
-class LocalItem(File, MusifyItem, metaclass=ABCMeta):
+class LocalItem(File, MusifyItemSettable, metaclass=ABCMeta):
     """Generic base class for locally-stored items"""
 
-    __attributes_classes__ = (File, MusifyItem)
+    __attributes_classes__ = (File, MusifyItemSettable)

--- a/musify/libraries/local/library/musicbee.py
+++ b/musify/libraries/local/library/musicbee.py
@@ -270,7 +270,7 @@ class MusicBee(LocalLibrary, File):
             # "Publisher": track.publisher,  # currently not supported by this program
             # "Encoder": track.encoder,  # currently not supported by this program
             "Size": track.size,
-            "Kind": track.kind,
+            "Kind": track.type,
             # "": track.channels,  # unknown MusicBee mapping
             "Bit Rate": int(track.bit_rate),
             # "": track.bit_depth,  # unknown MusicBee mapping

--- a/musify/libraries/local/track/field.py
+++ b/musify/libraries/local/track/field.py
@@ -38,7 +38,7 @@ class LocalTrackField(TrackFieldMixin):
     FILENAME = TagFields.FILENAME.value
     EXT = TagFields.EXT.value
     SIZE = TagFields.SIZE.value
-    KIND = TagFields.KIND.value
+    TYPE = TagFields.TYPE.value
     CHANNELS = TagFields.CHANNELS.value
     BIT_RATE = TagFields.BIT_RATE.value
     BIT_DEPTH = TagFields.BIT_DEPTH.value

--- a/musify/libraries/local/track/track.py
+++ b/musify/libraries/local/track/track.py
@@ -231,13 +231,10 @@ class LocalTrack[T: mutagen.FileType, U: TagReader, V: TagWriter](LocalItem, Tra
     def comments(self, value: UnitIterable[str] | None):
         self._comments = [value] if isinstance(value, str) else to_collection(value, list)
 
-    @property
-    def uri(self):
+    def _uri_getter(self):
         return self._uri
 
-    @uri.setter
-    def uri(self, value: str | None):
-        """Set both the ``uri`` property and the ``has_uri`` property ."""
+    def _uri_setter(self, value: str | None):
         if value is None:
             self._uri = None
             self._has_uri = None
@@ -288,8 +285,8 @@ class LocalTrack[T: mutagen.FileType, U: TagReader, V: TagWriter](LocalItem, Tra
         return self._reader.file.filename
 
     @property
-    def kind(self):
-        """The kind of audio file of this track"""
+    def type(self):
+        """The type of audio file of this track"""
         return self.__class__.__name__
 
     @property

--- a/musify/libraries/remote/core/library.py
+++ b/musify/libraries/remote/core/library.py
@@ -361,7 +361,6 @@ class RemoteLibrary[
         :param dry_run: When True, do not create playlists
             and just skip any playlists that are not already currently loaded.
         """
-        # TODO: expand this function to support all RemoteItem types + update input type
         if isinstance(playlists, Library):  # get URIs from playlists in library
             playlists = {name: [track.uri for track in pl] for name, pl in playlists.playlists.items()}
         elif (

--- a/musify/libraries/remote/core/object.py
+++ b/musify/libraries/remote/core/object.py
@@ -18,21 +18,14 @@ from musify.libraries.core.collection import MusifyCollection
 from musify.libraries.core.object import Track, Album, Playlist, Artist
 from musify.libraries.remote.core.api import RemoteAPI
 from musify.libraries.remote.core.base import RemoteObject, RemoteItem
-from musify.libraries.remote.core.enum import RemoteObjectType
 from musify.libraries.remote.core.exception import RemoteError
 from musify.utils import get_most_common_values
 
 
-class RemoteTrack(RemoteItem, Track, metaclass=ABCMeta):
+class RemoteTrack(Track, RemoteItem, metaclass=ABCMeta):
     """Extracts key ``track`` data from a remote API JSON response."""
 
     __attributes_classes__ = (Track, RemoteItem)
-
-    # noinspection PyPropertyDefinition
-    @classmethod
-    @property
-    def kind(cls):
-        return RemoteObjectType.TRACK
 
 
 class RemoteCollection[T: RemoteObject](MusifyCollection[T], metaclass=ABCMeta):
@@ -128,12 +121,6 @@ class RemotePlaylist[T: RemoteTrack](Playlist[T], RemoteCollectionLoader[T], met
     """Extracts key ``playlist`` data from a remote API JSON response."""
 
     __attributes_classes__ = (Playlist, RemoteCollectionLoader)
-
-    # noinspection PyPropertyDefinition
-    @classmethod
-    @property
-    def kind(cls):
-        return RemoteObjectType.PLAYLIST
 
     @property
     @abstractmethod
@@ -270,16 +257,10 @@ class RemotePlaylist[T: RemoteTrack](Playlist[T], RemoteCollectionLoader[T], met
         raise NotImplementedError
 
 
-class RemoteAlbum[T: RemoteTrack](RemoteCollectionLoader[T], Album[T], metaclass=ABCMeta):
+class RemoteAlbum[T: RemoteTrack](Album[T], RemoteCollectionLoader[T], metaclass=ABCMeta):
     """Extracts key ``album`` data from a remote API JSON response."""
 
     __attributes_classes__ = (Album, RemoteCollectionLoader)
-
-    # noinspection PyPropertyDefinition
-    @classmethod
-    @property
-    def kind(cls):
-        return RemoteObjectType.ALBUM
 
     @property
     def _total(self):
@@ -295,12 +276,6 @@ class RemoteArtist[T: RemoteTrack](Artist[T], RemoteCollectionLoader[T], metacla
     """Extracts key ``artist`` data from a remote API JSON response."""
 
     __attributes_classes__ = (Artist, RemoteCollectionLoader)
-
-    # noinspection PyPropertyDefinition
-    @classmethod
-    @property
-    def kind(cls):
-        return RemoteObjectType.ARTIST
 
     @property
     def _total(self):

--- a/musify/libraries/remote/spotify/api/item.py
+++ b/musify/libraries/remote/spotify/api/item.py
@@ -10,7 +10,7 @@ from urllib.parse import parse_qs, urlparse
 
 from musify.api.exception import APIError
 from musify.libraries.remote.core import RemoteResponse
-from musify.libraries.remote.core.enum import RemoteObjectType, RemoteIDType
+from musify.libraries.remote.core.enum import RemoteIDType, RemoteObjectType
 from musify.libraries.remote.core.exception import RemoteObjectTypeError
 from musify.libraries.remote.core.types import APIInputValue
 from musify.libraries.remote.spotify.api.base import SpotifyAPIBase

--- a/musify/libraries/remote/spotify/object.py
+++ b/musify/libraries/remote/spotify/object.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import Any, Self
 
 from musify.libraries.remote.core import RemoteResponse
-from musify.libraries.remote.core.enum import RemoteObjectType, RemoteIDType
+from musify.libraries.remote.core.enum import RemoteIDType, RemoteObjectType
 from musify.libraries.remote.core.object import RemoteCollectionLoader, RemoteTrack
 from musify.libraries.remote.core.object import RemotePlaylist, RemoteAlbum, RemoteArtist
 from musify.libraries.remote.spotify.api import SpotifyAPI

--- a/musify/processors/compare.py
+++ b/musify/processors/compare.py
@@ -45,7 +45,7 @@ field_name_map = {
     "FileName": Fields.FILENAME,
     "FileExtension": Fields.EXT,
     # "": Fields.SIZE,  # unmapped for compare
-    "FileKind": Fields.KIND,
+    "FileKind": Fields.TYPE,
     "FileBitrate": Fields.BIT_RATE,
     "BitDepth": Fields.BIT_DEPTH,
     "FileSampleRate": Fields.SAMPLE_RATE,
@@ -284,15 +284,15 @@ class Comparer(MusicBeeProcessor, DynamicProcessor):
 
     @dynamicprocessormethod
     def _starts_with(self, value: Any | None, expected: Sequence[Any] | None) -> bool:
-        return value.startswith(expected[0]) if value is not None and expected[0] is not None else False
+        return value.startswith(str(expected[0])) if value is not None and expected[0] is not None else False
 
     @dynamicprocessormethod
     def _ends_with(self, value: Any | None, expected: Sequence[Any] | None) -> bool:
-        return value.endswith(expected[0]) if value is not None and expected[0] is not None else False
+        return value.endswith(str(expected[0])) if value is not None and expected[0] is not None else False
 
     @dynamicprocessormethod
     def _contains(self, value: Any | None, expected: Sequence[Any] | None) -> bool:
-        return expected[0] in value if value is not None and expected[0] is not None else False
+        return str(expected[0]) in value if value is not None and expected[0] is not None else False
 
     @dynamicprocessormethod
     def _does_not_contain(self, value: Any | None, expected: Sequence[Any] | None) -> bool:
@@ -300,7 +300,7 @@ class Comparer(MusicBeeProcessor, DynamicProcessor):
 
     @dynamicprocessormethod
     def _matches_reg_ex(self, value: Any | None, expected: Sequence[Any] | None) -> bool:
-        return bool(re.search(expected[0], value)) if value is not None and expected[0] is not None else False
+        return bool(re.search(str(expected[0]), value)) if value is not None and expected[0] is not None else False
 
     @dynamicprocessormethod
     def _matches_reg_ex_ignore_case(self, value: Any | None, expected: Sequence[Any] | None) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,10 @@ from _pytest.fixtures import SubRequest
 
 from musify import MODULE_ROOT
 from musify.api.request import RequestHandler
-from musify.log.logger import MusifyLogger
 from musify.libraries.remote.core.enum import RemoteObjectType
 from musify.libraries.remote.spotify.api import SpotifyAPI
 from musify.libraries.remote.spotify.processors import SpotifyDataWrangler
+from musify.log.logger import MusifyLogger
 from tests.libraries.remote.core.utils import ALL_ITEM_TYPES
 from tests.libraries.remote.spotify.api.mock import SpotifyMock
 from tests.utils import idfn

--- a/tests/libraries/local/track/test_track.py
+++ b/tests/libraries/local/track/test_track.py
@@ -183,7 +183,7 @@ def test_loaded_attributes_common(track: LocalTrack):
     # file properties
     assert track.folder == basename(dirname(track.path))
     assert track.filename == splitext(basename(track.path))[0]
-    assert track.kind == track.__class__.__name__
+    assert track.type == track.__class__.__name__
     assert track.date_modified == datetime.fromtimestamp(getmtime(track.path))
 
     # library properties

--- a/tests/libraries/remote/spotify/api/test_artist.py
+++ b/tests/libraries/remote/spotify/api/test_artist.py
@@ -103,7 +103,6 @@ class TestSpotifyAPIArtists:
             assert reduced == expected[id_]
             self.assert_artist_albums_enriched(source[id_]["albums"]["items"])
 
-    # TODO: add assertions/tests for RemoteResponses input
     def test_get_artist_albums_single_string(
             self,
             artist_albums: list[dict[str, Any]],

--- a/tests/libraries/remote/spotify/api/test_item.py
+++ b/tests/libraries/remote/spotify/api/test_item.py
@@ -9,7 +9,7 @@ import pytest
 
 from musify.api.exception import APIError
 from musify.libraries.remote.core import RemoteResponse
-from musify.libraries.remote.core.enum import RemoteObjectType, RemoteIDType
+from musify.libraries.remote.core.enum import RemoteIDType, RemoteObjectType
 from musify.libraries.remote.core.exception import RemoteObjectTypeError
 from musify.libraries.remote.core.object import RemoteCollection
 from musify.libraries.remote.spotify.api import SpotifyAPI

--- a/tests/libraries/remote/spotify/object/test_album.py
+++ b/tests/libraries/remote/spotify/object/test_album.py
@@ -10,9 +10,9 @@ import pytest
 from musify.api.exception import APIError
 from musify.libraries.remote.core.enum import RemoteObjectType
 from musify.libraries.remote.core.exception import RemoteObjectTypeError, RemoteError
-from musify.types import Number
 from musify.libraries.remote.spotify.api import SpotifyAPI
 from musify.libraries.remote.spotify.object import SpotifyAlbum, SpotifyTrack
+from musify.types import Number
 from tests.libraries.remote.spotify.api.mock import SpotifyMock
 from tests.libraries.remote.spotify.object.testers import SpotifyCollectionLoaderTester
 from tests.libraries.remote.spotify.utils import assert_id_attributes

--- a/tests/libraries/remote/spotify/object/test_track.py
+++ b/tests/libraries/remote/spotify/object/test_track.py
@@ -7,9 +7,9 @@ import pytest
 
 from musify.api.exception import APIError
 from musify.libraries.remote.core.exception import RemoteObjectTypeError
-from musify.types import Number
 from musify.libraries.remote.spotify.api import SpotifyAPI
 from musify.libraries.remote.spotify.object import SpotifyTrack
+from musify.types import Number
 from tests.core.base import MusifyItemTester
 from tests.libraries.remote.spotify.api.mock import SpotifyMock
 from tests.libraries.remote.spotify.utils import assert_id_attributes

--- a/tests/libraries/remote/spotify/test_library.py
+++ b/tests/libraries/remote/spotify/test_library.py
@@ -4,11 +4,11 @@ from urllib.parse import parse_qs
 
 import pytest
 
-from musify.processors.filter import FilterDefinedList, FilterIncludeExclude
 from musify.libraries.remote.core.enum import RemoteObjectType
 from musify.libraries.remote.spotify.api import SpotifyAPI
 from musify.libraries.remote.spotify.library import SpotifyLibrary
 from musify.libraries.remote.spotify.object import SpotifyTrack
+from musify.processors.filter import FilterDefinedList, FilterIncludeExclude
 from tests.libraries.remote.core.library import RemoteLibraryTester
 from tests.libraries.remote.spotify.api.mock import SpotifyMock
 

--- a/tests/processors/test_compare.py
+++ b/tests/processors/test_compare.py
@@ -3,15 +3,15 @@ from datetime import datetime, date, timedelta
 import pytest
 import xmltodict
 
+from musify.field import TrackField
 from musify.libraries.local.track import MP3, M4A, FLAC
 from musify.libraries.local.track.field import LocalTrackField
 from musify.processors.compare import Comparer
 from musify.processors.exception import ComparerError, ProcessorLookupError
-from musify.field import TrackField
 from musify.utils import to_collection
+from tests.core.printer import PrettyPrinterTester
 from tests.libraries.local.track.utils import random_track
 from tests.libraries.local.utils import path_playlist_xautopf_bp, path_playlist_xautopf_ra
-from tests.core.printer import PrettyPrinterTester
 
 
 class TestComparer(PrettyPrinterTester):

--- a/tests/processors/test_download.py
+++ b/tests/processors/test_download.py
@@ -5,12 +5,12 @@ import pytest
 from pytest_mock import MockerFixture
 
 from musify import MODULE_ROOT
-from musify.libraries.local.track import LocalTrack
-from musify.processors.download import ItemDownloadHelper
 from musify.core.enum import Fields
 from musify.libraries.collection import BasicCollection
-from tests.libraries.local.track.utils import random_tracks
+from musify.libraries.local.track import LocalTrack
+from musify.processors.download import ItemDownloadHelper
 from tests.core.printer import PrettyPrinterTester
+from tests.libraries.local.track.utils import random_tracks
 from tests.libraries.remote.core.processors.utils import patch_input
 from tests.utils import random_str, get_stdout
 

--- a/tests/processors/test_filter.py
+++ b/tests/processors/test_filter.py
@@ -6,18 +6,18 @@ from random import sample, shuffle, randrange
 import pytest
 import xmltodict
 
+from musify.core.enum import Fields
+from musify.file.path_mapper import PathStemMapper, PathMapper
 from musify.libraries.local.track import LocalTrack
 from musify.libraries.local.track.field import LocalTrackField
 from musify.processors.compare import Comparer
 from musify.processors.filter import FilterDefinedList, FilterComparers, FilterIncludeExclude
 from musify.processors.filter_matcher import FilterMatcher
-from musify.core.enum import Fields
-from musify.file.path_mapper import PathStemMapper, PathMapper
+from tests.core.printer import PrettyPrinterTester
 from tests.libraries.local.track.utils import random_tracks
 from tests.libraries.local.utils import path_playlist_resources
 from tests.libraries.local.utils import path_playlist_xautopf_bp, path_playlist_xautopf_ra, path_playlist_xautopf_cm
 from tests.libraries.local.utils import path_track_all, path_track_wma, path_track_flac, path_track_mp3
-from tests.core.printer import PrettyPrinterTester
 from tests.utils import random_str, path_resources
 
 

--- a/tests/processors/test_limit.py
+++ b/tests/processors/test_limit.py
@@ -6,9 +6,9 @@ import xmltodict
 
 from musify.libraries.local.track import LocalTrack
 from musify.processors.limit import ItemLimiter, LimitType
+from tests.core.printer import PrettyPrinterTester
 from tests.libraries.local.track.utils import random_tracks
 from tests.libraries.local.utils import path_playlist_xautopf_bp, path_playlist_xautopf_ra
-from tests.core.printer import PrettyPrinterTester
 from tests.utils import random_file
 
 

--- a/tests/processors/test_match.py
+++ b/tests/processors/test_match.py
@@ -1,10 +1,10 @@
 import pytest
 
+from musify.core.enum import TagFields as Tag
 from musify.libraries.local.track import LocalTrack
 from musify.processors.match import ItemMatcher, CleanTagConfig
-from musify.core.enum import TagFields as Tag
-from tests.libraries.local.track.utils import random_track
 from tests.core.printer import PrettyPrinterTester
+from tests.libraries.local.track.utils import random_track
 
 
 class TestItemMatcher(PrettyPrinterTester):

--- a/tests/processors/test_sort.py
+++ b/tests/processors/test_sort.py
@@ -5,14 +5,14 @@ from random import choice, randrange
 import pytest
 import xmltodict
 
+from musify.field import TrackField
 from musify.libraries.local.track import LocalTrack
 from musify.libraries.local.track.field import LocalTrackField
 from musify.processors.sort import ItemSorter, ShuffleMode, ShuffleBy
-from musify.field import TrackField
 from musify.utils import strip_ignore_words
+from tests.core.printer import PrettyPrinterTester
 from tests.libraries.local.track.utils import random_tracks
 from tests.libraries.local.utils import path_playlist_xautopf_bp, path_playlist_xautopf_ra
-from tests.core.printer import PrettyPrinterTester
 
 
 class TestItemSorter(PrettyPrinterTester):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,10 +1,10 @@
 import pytest
 
-from musify.libraries.local.track import LocalTrack
-from musify.libraries.local.track.field import LocalTrackField
-from musify.libraries.core.object import Track, Playlist, Folder, Artist, Album
 from musify.field import FolderField, PlaylistField, AlbumField, ArtistField
 from musify.field import TrackField
+from musify.libraries.core.object import Track, Playlist, Folder, Artist, Album
+from musify.libraries.local.track import LocalTrack
+from musify.libraries.local.track.field import LocalTrackField
 from tests.core.enum import FieldTester, TagFieldTester
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -8,11 +8,11 @@ import pytest
 from musify.libraries.local.library import LocalLibrary
 from musify.libraries.local.playlist import M3U
 from musify.libraries.local.track.field import LocalTrackField
-from musify.report import report_playlist_differences, report_missing_tags
 from musify.libraries.remote.spotify.api import SpotifyAPI
 from musify.libraries.remote.spotify.library import SpotifyLibrary
 from musify.libraries.remote.spotify.object import SpotifyPlaylist
 from musify.libraries.remote.spotify.processors import SpotifyDataWrangler
+from musify.report import report_playlist_differences, report_missing_tags
 from tests.libraries.local.track.utils import random_track
 from tests.libraries.remote.spotify.api.mock import SpotifyMock
 from tests.libraries.remote.spotify.utils import random_uri


### PR DESCRIPTION
Added
-----

* Property 'kind' to all objects which have an associated :py:class:`.RemoteObjectType`
* Introduced :py:class:`.MusifyItemSettable` class to allow distinction
  between items that can have their properties set and those that can't

Changed
-------

* Renamed 'kind' property on :py:class:`.LocalTrack` to 'type' to avoid clashing property names
* :py:class:`.ItemMatcher`, :py:class:`.RemoteItemChecker`, and :py:class:`.RemoteItemSearcher` now accept
  all MusifyItem types that may have their URI property set manually.

Fixed
-----

* :py:class:`.Comparer` dynamic processor methods which process string values now cast expected types before processing