### PR TITLE
expand FilterMatcher functionality with GroupBy settings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,3 +6,5 @@ per-file-ignores =
     docs/_howto/scripts/*:E402
     tests/**/test_*.py:F811
 max-line-length = 120
+# TODO: reduce this to 10
+max-complexity = 17

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -46,6 +46,16 @@ To run tests, you must have installed either the ``test`` or ``dev`` optional de
    # OR
    pytest path/to/test/file.py
 
+As part of code validation, your code will be required to pass certain linting checks.
+This project uses flake8 to help give an indication as to the quality of your code.
+For the current checks that your code will be expected to pass,
+please check the ``.flake8`` config file in the root of the project.
+
+To run these checks locally, simply run the following command in a terminal:
+
+.. code-block:: bash
+
+   flake8
 
 Submitting your changes for review
 ==================================

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -58,6 +58,8 @@ Changed
 * Renamed 'kind' property on :py:class:`.LocalTrack` to 'type' to avoid clashing property names
 * :py:class:`.ItemMatcher`, :py:class:`.RemoteItemChecker`, and :py:class:`.RemoteItemSearcher` now accept
   all MusifyItem types that may have their URI property set manually.
+* :py:class:`.ItemSorter` now shuffles randomly on unsupported types
+  + prioritises fields settings over shuffle settings
 
 Fixed
 -----

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -69,6 +69,11 @@ Removed
 
 * Redundant ShuffleBy enum and related arguments from :py:class:`.ItemSorter`
 
+Documentation
+-------------
+
+* Added info on lint checking for the contributing page
+
 0.8.1
 =====
 

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -42,6 +42,7 @@ Added
 * Property 'kind' to all objects which have an associated :py:class:`.RemoteObjectType`
 * Introduced :py:class:`.MusifyItemSettable` class to allow distinction
   between items that can have their properties set and those that can't
+* Extend :py:class:`.FilterMatcher` with group_by tag functionality
 
 Changed
 -------
@@ -62,6 +63,11 @@ Fixed
 -----
 
 * :py:class:`.Comparer` dynamic processor methods which process string values now cast expected types before processing
+
+Removed
+-------
+
+* Redundant ShuffleBy enum and related arguments from :py:class:`.ItemSorter`
 
 0.8.1
 =====

--- a/musify/core/enum.py
+++ b/musify/core/enum.py
@@ -17,7 +17,7 @@ class MusifyEnum(IntEnum):
     @classmethod
     def map(cls, enum: Self) -> list[Self]:
         """
-        "Optional mapper to apply to the enum found during :py:meth:`all`, :py:meth:`from_name`,
+        Optional mapper to apply to the enum found during :py:meth:`all`, :py:meth:`from_name`,
         and :py:meth:`from_value` calls
         """
         return [enum]

--- a/musify/field.py
+++ b/musify/field.py
@@ -13,15 +13,6 @@ class TrackFieldMixin(TagField):
     # noinspection PyUnresolvedReferences
     @classmethod
     def map(cls, enum: Self) -> list[Self]:
-        """
-        Mapper to apply to the enum found during :py:meth:`from_name` and :py:meth:`from_value` calls,
-        or from :py:meth:`to_tag` and :py:meth:`to_tags` calls
-
-        Applies the following mapping:
-            * ``TRACK`` returns both ``TRACK_NUMBER`` and ``TRACK_TOTAL`` enums
-            * ``DISC`` returns both ``DISC_NUMBER`` and ``DISC_TOTAL`` enums
-            * all other enums return the enum in a unit list
-        """
         if enum == cls.TRACK:
             return [cls.TRACK_NUMBER, cls.TRACK_TOTAL]
         elif enum == cls.DISC:

--- a/musify/libraries/core/collection.py
+++ b/musify/libraries/core/collection.py
@@ -15,7 +15,7 @@ from musify.file.base import File
 from musify.libraries.remote.core import RemoteResponse
 from musify.libraries.remote.core.base import RemoteObject
 from musify.libraries.remote.core.processors.wrangle import RemoteDataWrangler
-from musify.processors.sort import ShuffleMode, ShuffleBy, ItemSorter
+from musify.processors.sort import ShuffleMode, ItemSorter
 from musify.types import UnitSequence
 
 
@@ -196,7 +196,6 @@ class MusifyCollection[T: MusifyItem](MusifyObject, MutableSequence[T], metaclas
             self,
             fields: UnitSequence[Field | None] | Mapping[Field | None, bool] = (),
             shuffle_mode: ShuffleMode = ShuffleMode.NONE,
-            shuffle_by: ShuffleBy = ShuffleBy.TRACK,
             shuffle_weight: float = 1.0,
             key: Field | None = None,
             reverse: bool = False,
@@ -210,7 +209,6 @@ class MusifyCollection[T: MusifyItem](MusifyObject, MutableSequence[T], metaclas
             * List of tags/properties to sort by.
             * Map of `{<tag/property>: <reversed>}`. If reversed is true, sort the ``tag/property`` in reverse.
         :param shuffle_mode: The mode to use for shuffling.
-        :param shuffle_by: The field to shuffle by when shuffling.
         :param shuffle_weight: The weights (between 0 and 1) to apply to shuffling modes that can use it.
             This value will automatically be limited to within the accepted range 0 and 1.
         :param key: Tag or property to sort on. Can be given instead of ``fields`` for a simple sort.
@@ -221,9 +219,7 @@ class MusifyCollection[T: MusifyItem](MusifyObject, MutableSequence[T], metaclas
         if key is not None:
             ItemSorter.sort_by_field(self.items, field=key)
         else:
-            ItemSorter(
-                fields=fields, shuffle_mode=shuffle_mode, shuffle_by=shuffle_by, shuffle_weight=shuffle_weight
-            )(self.items)
+            ItemSorter(fields=fields, shuffle_mode=shuffle_mode, shuffle_weight=shuffle_weight)(self.items)
 
         if reverse:
             self.items.reverse()

--- a/musify/libraries/core/collection.py
+++ b/musify/libraries/core/collection.py
@@ -195,7 +195,7 @@ class MusifyCollection[T: MusifyItem](MusifyObject, MutableSequence[T], metaclas
     def sort(
             self,
             fields: UnitSequence[Field | None] | Mapping[Field | None, bool] = (),
-            shuffle_mode: ShuffleMode = ShuffleMode.NONE,
+            shuffle_mode: ShuffleMode | None = None,
             shuffle_weight: float = 1.0,
             key: Field | None = None,
             reverse: bool = False,

--- a/musify/libraries/core/object.py
+++ b/musify/libraries/core/object.py
@@ -29,7 +29,8 @@ class Track(MusifyItem, metaclass=ABCMeta):
     # noinspection PyPropertyDefinition
     @classmethod
     @property
-    def kind(cls):
+    def kind(cls) -> RemoteObjectType:
+        """The type of remote object associated with this class"""
         return RemoteObjectType.TRACK
 
     @property
@@ -180,7 +181,8 @@ class Playlist[T: Track](MusifyCollection[T], metaclass=ABCMeta):
     # noinspection PyPropertyDefinition
     @classmethod
     @property
-    def kind(cls):
+    def kind(cls) -> RemoteObjectType:
+        """The type of remote object associated with this class"""
         return RemoteObjectType.PLAYLIST
 
     @property
@@ -477,7 +479,8 @@ class Album[T: Track](MusifyCollection[T], metaclass=ABCMeta):
     # noinspection PyPropertyDefinition
     @classmethod
     @property
-    def kind(cls):
+    def kind(cls) -> RemoteObjectType:
+        """The type of remote object associated with this class"""
         return RemoteObjectType.ALBUM
 
     @property
@@ -599,7 +602,8 @@ class Artist[T: Track](MusifyCollection[T], metaclass=ABCMeta):
     # noinspection PyPropertyDefinition
     @classmethod
     @property
-    def kind(cls):
+    def kind(cls) -> RemoteObjectType:
+        """The type of remote object associated with this class"""
         return RemoteObjectType.ARTIST
 
     @property

--- a/musify/libraries/local/playlist/xautopf.py
+++ b/musify/libraries/local/playlist/xautopf.py
@@ -18,6 +18,7 @@ from musify.processors.filter import FilterDefinedList, FilterComparers
 from musify.processors.filter_matcher import FilterMatcher
 from musify.processors.limit import ItemLimiter
 from musify.processors.sort import ItemSorter
+from musify.utils import merge_maps
 
 
 @dataclass(frozen=True)
@@ -169,18 +170,12 @@ class XAutoPF(LocalPlaylist[FilterMatcher[
 
     def _update_xml_paths(self, xml: dict[str, Any]) -> None:
         """Update the stored, parsed XML object with valid include and exclude paths"""
-        source = xml["SmartPlaylist"]["Source"]
         output = self.matcher.to_xml(
             items=self.tracks,
             original=self._original,
             path_mapper=lambda paths: self.path_mapper.unmap_many(paths, check_existence=False)
         )
-
-        # assign values to stored, parsed XML map
-        for k, v in output.items():
-            source.pop(k, None)
-            if output.get(k):
-                source[k] = v
+        merge_maps(source=xml, new=output, extend=False, overwrite=True)
 
     def _update_comparers(self, xml: dict[str, Any]) -> None:
         """Update the stored, parsed XML object with appropriately formatted comparer settings"""

--- a/musify/libraries/remote/core/response.py
+++ b/musify/libraries/remote/core/response.py
@@ -27,7 +27,7 @@ class RemoteResponse(MusifyObject, metaclass=ABCMeta):
     @property
     @abstractmethod
     def kind(cls) -> RemoteObjectType:
-        """The type of remote object this python object represents"""
+        """The type of remote object this class represents"""
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/__resources/playlist/Recently Added.xautopf
+++ b/tests/__resources/playlist/Recently Added.xautopf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<SmartPlaylist SaveStaticCopy="False" LiveUpdating="True" Layout="4" LayoutGroupBy="0" ShuffleMode="None" ShuffleSameArtistWeight="-0.2" MinimumArtistGap="0" GroupBy="track" ConsolidateAlbums="False" MusicLibraryPath="/mnt/d/Music/">
+<SmartPlaylist SaveStaticCopy="False" LiveUpdating="True" Layout="4" LayoutGroupBy="0" ShuffleMode="DifferentArtist" ShuffleSameArtistWeight="-0.2" MinimumArtistGap="0" GroupBy="track" ConsolidateAlbums="False" MusicLibraryPath="/mnt/d/Music/">
   <Source Type="1">
     <Description />
     <Conditions CombineMethod="Any">

--- a/tests/processors/test_sort.py
+++ b/tests/processors/test_sort.py
@@ -8,7 +8,7 @@ import xmltodict
 from musify.field import TrackField
 from musify.libraries.local.track import LocalTrack
 from musify.libraries.local.track.field import LocalTrackField
-from musify.processors.sort import ItemSorter, ShuffleMode, ShuffleBy
+from musify.processors.sort import ItemSorter, ShuffleMode
 from musify.utils import strip_ignore_words
 from tests.core.printer import PrettyPrinterTester
 from tests.libraries.local.track.utils import random_tracks
@@ -111,7 +111,6 @@ class TestItemSorter(PrettyPrinterTester):
 
         assert sorter.sort_fields == {LocalTrackField.TRACK_NUMBER: False}
         assert sorter.shuffle_mode == ShuffleMode.NONE  # switch to ShuffleMode.RECENT_ADDED once implemented
-        assert sorter.shuffle_by == ShuffleBy.ALBUM
         assert sorter.shuffle_weight == 0.5
 
     def test_from_xml_ra(self):
@@ -121,7 +120,6 @@ class TestItemSorter(PrettyPrinterTester):
 
         assert sorter.sort_fields == {LocalTrackField.DATE_ADDED: True}
         assert sorter.shuffle_mode == ShuffleMode.NONE
-        assert sorter.shuffle_by == ShuffleBy.TRACK
         assert sorter.shuffle_weight == -0.2
 
     @pytest.mark.skip(reason="not implemented yet")


### PR DESCRIPTION
Begins to resolve #18 by clearing up some overlapping logical errors in `ItemSorter` and `FilterMatcher`

Added
-----

* Extend :py:class:`.FilterMatcher` with group_by tag functionality

Changed
-------

* :py:class:`.ItemSorter` now shuffles randomly on unsupported types
  + prioritises fields settings over shuffle settings

Removed
-------

* Redundant ShuffleBy enum and related arguments from :py:class:`.ItemSorter`

Documentation
-------------

* Added info on lint checking for the contributing page