### PR TITLE
expand `XAutoPF` functionality

### DIFF
--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -43,6 +43,11 @@ Added
 * Introduced :py:class:`.MusifyItemSettable` class to allow distinction
   between items that can have their properties set and those that can't
 * Extend :py:class:`.FilterMatcher` with group_by tag functionality
+* Now fully supports parsing of processors relating to XAutoPF objects with full I/O of settings
+  to/from their related XML files on disk.
+* Now supports creating new XAutoPF files from scratch without the file needing to already exist.
+  For XML values not directly controlled by Musify, users can use the 'default_xml' class attribute
+  to control the initial default values applied in this scenario.
 
 Changed
 -------

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -62,6 +62,10 @@ Changed
   + prioritises fields settings over shuffle settings
 * :py:meth:`.Comparer._in_range` now uses inclusive range i.e. ``a <= x <= b`` where ``x`` is the value to compare
   and ``a`` and ``b`` are the limits. Previously used exclusive range i.e. ``a < x < b``
+* Removed ``from_xml`` and ``to_xml`` methods from all :py:class:`.MusicBeeProcessor` subclasses.
+  Moved this logic to :py:class:`.XMLPlaylistParser` as distinct 'get' methods for each processor type.
+* Moved loading of XML file logic from :py:class:`.XAutoPF` to :py:class:`.XMLPlaylistParser`.
+  :py:class:`.XMLPlaylistParser` is now solely responsible for all XML parsing and handling for XAutoPF files
 
 Fixed
 -----

--- a/musify/core/printer.py
+++ b/musify/core/printer.py
@@ -19,15 +19,16 @@ class PrettyPrinter(ABC):
 
     @staticmethod
     def _pascal_to_snake(value: str) -> str:
-        """Convert snake_case to CamelCase."""
+        """Convert PascalCase to snake_case."""
         value = re.sub(r"([A-Z])", lambda m: f"_{m.group(1).lower()}", value.strip("_ "))
         value = re.sub(r"[_ ]+", "_", value).strip("_ ")
         return value.lower()
 
     @staticmethod
     def _snake_to_pascal(value: str) -> str:
-        """Convert snake_case to CamelCase."""
-        return re.sub(r"_(.)", lambda m: m.group(1).upper(), value.strip())
+        """Convert snake_case to PascalCase."""
+        value = re.sub(r"_(.)", lambda m: m.group(1).upper(), value.strip().lower())
+        return re.sub(r"^(.)", lambda m: m.group(1).upper(), value.strip())
 
     @abstractmethod
     def as_dict(self) -> dict[str, Any]:

--- a/musify/file/base.py
+++ b/musify/file/base.py
@@ -91,7 +91,7 @@ class File(Hashable, metaclass=ABCMeta):
         """
         Save this object to file.
 
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         """
         raise NotImplementedError
 

--- a/musify/libraries/local/collection.py
+++ b/musify/libraries/local/collection.py
@@ -119,7 +119,7 @@ class LocalCollection[T: LocalTrack](MusifyCollection[T], metaclass=ABCMeta):
 
         :param tags: Tags to be updated.
         :param replace: Destructively replace tags in each file.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: A map of the :py:class:`LocalTrack` saved to its result as a :py:class:`SyncResultTrack` object
         """
         bar = self.logger.get_progress_bar(iterable=self.tracks, desc="Updating tracks", unit="tracks")

--- a/musify/libraries/local/exception.py
+++ b/musify/libraries/local/exception.py
@@ -43,8 +43,11 @@ class LocalCollectionError(LocalError):
         super().__init__(formatted)
 
 
-class LocalProcessorError(LocalError):
-    """Exception raised for errors related to track processors."""
+###########################################################################
+## Track errors
+###########################################################################
+class TagError(LocalError):
+    """Exception raised for errors related to track tag errors."""
 
 
 ###########################################################################

--- a/musify/libraries/local/library/library.py
+++ b/musify/libraries/local/library/library.py
@@ -379,7 +379,7 @@ class LocalLibrary(LocalCollection[LocalTrack], Library[LocalTrack]):
         """
         For each Playlist in this Library, saves its associate tracks and its settings (if applicable) to file.
 
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: A map of the playlist name to the results of its sync as a :py:class:`Result` object.
         """
         return {name: pl.save(dry_run=dry_run) for name, pl in self.playlists.items()}

--- a/musify/libraries/local/library/musicbee.py
+++ b/musify/libraries/local/library/musicbee.py
@@ -151,7 +151,7 @@ class MusicBee(LocalLibrary, File):
         """
         Generate and save the XML library file for this MusicBee library.
 
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: Map representation of the saved XML file.
         """
         self.logger.debug(f"Save {self.name} library file: START")
@@ -509,7 +509,7 @@ class XMLLibraryParser:
         Un-parse a map of XML data to XML and save to file.
 
         :param data: Map of XML data to export.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         """
         et: etree._ElementTree = etree.parse(self.path)
         parsed: dict[str, Any] = xmltodict.parse(etree.tostring(et.getroot(), encoding='utf-8', method='xml'))

--- a/musify/libraries/local/playlist/base.py
+++ b/musify/libraries/local/playlist/base.py
@@ -139,7 +139,7 @@ class LocalPlaylist[T: Filter[LocalTrack]](LocalCollection[LocalTrack], Playlist
         """
         Write the tracks in this Playlist and its settings (if applicable) to file.
 
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: :py:class:`Result` object with stats on the changes to the playlist.
         """
         raise NotImplementedError

--- a/musify/libraries/local/playlist/m3u.py
+++ b/musify/libraries/local/playlist/m3u.py
@@ -114,7 +114,7 @@ class M3U(LocalPlaylist[FilterDefinedList[str | File]]):
         """
         Write the tracks in this Playlist and its settings (if applicable) to file.
 
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The results of the sync as a :py:class:`SyncResultM3U` object.
         """
         start_paths = {path.casefold() for path in self.path_mapper.unmap_many(self._original, check_existence=False)}

--- a/musify/libraries/local/playlist/xautopf.py
+++ b/musify/libraries/local/playlist/xautopf.py
@@ -1,7 +1,7 @@
 """
 The XAutoPF implementation of a :py:class:`LocalPlaylist`.
 """
-from collections.abc import Collection
+from collections.abc import Collection, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from os.path import exists
@@ -9,16 +9,25 @@ from typing import Any
 
 import xmltodict
 
-from musify.core.enum import Fields
+from musify.core.base import MusifyItem
+from musify.core.enum import Fields, Field, TagFields
+from musify.core.printer import PrettyPrinter
 from musify.core.result import Result
+from musify.exception import FieldError
+from musify.file.base import File
 from musify.file.path_mapper import PathMapper
 from musify.libraries.local.playlist.base import LocalPlaylist
 from musify.libraries.local.track import LocalTrack
+from musify.processors.compare import Comparer
 from musify.processors.filter import FilterDefinedList, FilterComparers
 from musify.processors.filter_matcher import FilterMatcher
-from musify.processors.limit import ItemLimiter
-from musify.processors.sort import ItemSorter
-from musify.utils import merge_maps
+from musify.processors.limit import ItemLimiter, LimitType
+from musify.processors.sort import ItemSorter, ShuffleMode
+from musify.utils import merge_maps, to_collection
+
+AutoMatcher = FilterMatcher[
+    LocalTrack, FilterDefinedList[LocalTrack], FilterDefinedList[LocalTrack], FilterComparers[LocalTrack]
+]
 
 
 @dataclass(frozen=True)
@@ -55,9 +64,7 @@ class SyncResultXAutoPF(Result):
     final_sorter: bool
 
 
-class XAutoPF(LocalPlaylist[FilterMatcher[
-    LocalTrack, FilterDefinedList[LocalTrack], FilterDefinedList[LocalTrack], FilterComparers[LocalTrack]
-]]):
+class XAutoPF(LocalPlaylist[AutoMatcher]):
     """
     For reading and writing data from MusicBee's auto-playlist format.
 
@@ -71,7 +78,7 @@ class XAutoPF(LocalPlaylist[FilterMatcher[
         mapped to absolute, system-specific paths to be loaded and back again when saved.
     """
 
-    __slots__ = ("_description", "xml",)
+    __slots__ = ("_parser", "_description",)
 
     valid_extensions = frozenset({".xautopf"})
 
@@ -98,18 +105,15 @@ class XAutoPF(LocalPlaylist[FilterMatcher[
                 "This program is not yet able to create this playlist type from scratch."
             )
 
-        with open(path, "r", encoding="utf-8") as file:
-            #: A map representation of the loaded XML playlist data
-            self.xml: dict[str, Any] = xmltodict.parse(file.read())
-
-        self._description = self.xml["SmartPlaylist"]["Source"]["Description"]
+        self._parser = XMLPlaylistParser(path=path, path_mapper=path_mapper)
+        self._description = self._parser.xml_source["Description"]
 
         super().__init__(
             path=path,
-            matcher=FilterMatcher.from_xml(xml=self.xml, path_mapper=path_mapper),
-            limiter=ItemLimiter.from_xml(xml=self.xml),
-            sorter=ItemSorter.from_xml(xml=self.xml),
-            path_mapper=path_mapper,
+            matcher=self._parser.get_matcher(),
+            limiter=self._parser.get_limiter(),
+            sorter=self._parser.get_sorter(),
+            path_mapper=self._parser.path_mapper,
         )
 
         self.load(tracks=tracks)
@@ -173,7 +177,7 @@ class XAutoPF(LocalPlaylist[FilterMatcher[
         output = self.matcher.to_xml(
             items=self.tracks,
             original=self._original,
-            path_mapper=lambda paths: self.path_mapper.unmap_many(paths, check_existence=False)
+            path_mapper=""
         )
         merge_maps(source=xml, new=output, extend=False, overwrite=True)
 
@@ -197,3 +201,262 @@ class XAutoPF(LocalPlaylist[FilterMatcher[
         with open(self.path, 'w', encoding="utf-8") as file:
             xml_str = xmltodict.unparse(self.xml, pretty=True, short_empty_elements=True)
             file.write(xml_str.replace("/>", " />").replace('\t', '  '))
+
+
+class XMLPlaylistParser(PrettyPrinter):
+
+    __slots__ = ("path", "path_mapper",)
+
+    # noinspection SpellCheckingInspection
+    #: Map of MusicBee field name to Field enum
+    field_name_map = {
+        "None": None,
+        "Title": Fields.TITLE,
+        "ArtistPeople": Fields.ARTIST,
+        "Album": Fields.ALBUM,  # album ignoring articles like 'the' and 'a' etc.
+        "Album Artist": Fields.ALBUM_ARTIST,
+        "TrackNo": Fields.TRACK_NUMBER,
+        "TrackCount": Fields.TRACK_TOTAL,
+        "GenreSplits": Fields.GENRES,
+        "Year": Fields.YEAR,  # could also be 'YearOnly'?
+        "BeatsPerMin": Fields.BPM,
+        "DiscNo": Fields.DISC_NUMBER,
+        "DiscCount": Fields.DISC_TOTAL,
+        # "": Fields.COMPILATION,  # unmapped for compare
+        "Comment": Fields.COMMENTS,
+        "FileDuration": Fields.LENGTH,
+        "Rating": Fields.RATING,
+        # "ComposerPeople": Fields.COMPOSER,  # currently not supported by this program
+        # "Conductor": Fields.CONDUCTOR,  # currently not supported by this program
+        # "Publisher": Fields.PUBLISHER,  # currently not supported by this program
+        "FilePath": Fields.PATH,
+        "FolderName": Fields.FOLDER,
+        "FileName": Fields.FILENAME,
+        "FileExtension": Fields.EXT,
+        # "": Fields.SIZE,  # unmapped for compare
+        "FileKind": Fields.TYPE,
+        "FileBitrate": Fields.BIT_RATE,
+        "BitDepth": Fields.BIT_DEPTH,
+        "FileSampleRate": Fields.SAMPLE_RATE,
+        "FileChannels": Fields.CHANNELS,
+        # "": Fields.DATE_CREATED,  # unmapped for compare
+        "FileDateModified": Fields.DATE_MODIFIED,
+        "FileDateAdded": Fields.DATE_ADDED,
+        "FileLastPlayed": Fields.LAST_PLAYED,
+        "FilePlayCount": Fields.PLAY_COUNT,
+    }
+
+    #: Settings for custom sort codes.
+    custom_sort: dict[int, Mapping[Field, bool]] = {
+        6: {
+            Fields.ALBUM: False,
+            Fields.DISC_NUMBER: False,
+            Fields.TRACK_NUMBER: False,
+            Fields.FILENAME: False
+        }
+        # TODO: implement field_code 78 - manual order according to the order of tracks found
+        #  in the MusicBee library file for a given playlist.
+    }
+
+    @property
+    def xml_smart_playlist(self) -> dict[str, Any]:
+        """The smart playlist data part of the loaded XML playlist data"""
+        return self.xml["SmartPlaylist"]
+
+    @property
+    def xml_source(self) -> dict[str, Any]:
+        """The source data part of the loaded XML playlist data"""
+        return self.xml_smart_playlist["Source"]
+
+    def __init__(self, path: str, path_mapper: PathMapper = PathMapper()):
+        self.path = path
+        with open(self.path, "r", encoding="utf-8") as file:
+            #: A map representation of the loaded XML playlist data
+            self.xml: dict[str, Any] = xmltodict.parse(file.read())
+
+        self.path_mapper = path_mapper
+
+    def _get_comparer(self, xml: Mapping[str, Any]) -> Comparer:
+        """
+        Initialise and return a :py:class:`Comparer` from the relevant chunk of settings in ``xml`` playlist data.
+
+        :param xml: The relevant chunk to generate a single :py:class:`Comparer` as found in
+            the loaded XML object for this playlist.
+            This function expects to be given only the XML part related to one Comparer condition.
+        :return: The initialised :py:class:`Comparer`.
+        """
+        field_str = xml.get("@Field", "None")
+        field: Field = self.field_name_map.get(field_str)
+        if field is None:
+            raise FieldError("Unrecognised field name", field=field_str)
+
+        expected: tuple[str, ...] | None = tuple(v for k, v in xml.items() if k.startswith("@Value"))
+        if len(expected) == 0 or expected[0] == "[playing track]":
+            expected = None
+
+        return Comparer(condition=xml["@Comparison"], expected=expected, field=field)
+
+    def _get_xml_from_comparer(self, comparer: Comparer) -> dict[str, Any]:
+        """Parse the given ``comparer`` to its XML playlist representation."""
+
+    def get_matcher(self) -> AutoMatcher:
+        """Initialise and return a :py:class:`FilterMatcher` object from loaded XML playlist data."""
+        # tracks to include/exclude even if they meet/don't meet match compare conditions
+        include_str: str = self.xml_source.get("ExceptionsInclude") or ""
+        include = self.path_mapper.map_many(set(include_str.split("|")), check_existence=True)
+        exclude_str: str = self.xml_source.get("Exceptions") or ""
+        exclude = self.path_mapper.map_many(set(exclude_str.split("|")), check_existence=True)
+
+        comparers: dict[Comparer, tuple[bool, FilterComparers]] = {}
+        for condition in to_collection(self.xml_source["Conditions"]["Condition"]):
+            if any(key in condition for key in {"And", "Or"}):
+                combine = "And" in condition
+                conditions = condition["And" if combine else "Or"]
+                sub_filter = FilterComparers(
+                    comparers=[self._get_comparer(sub) for sub in to_collection(conditions["Condition"])],
+                    match_all=conditions["@CombineMethod"] == "All"
+                )
+            else:
+                combine = False
+                sub_filter = FilterComparers()
+
+            comparers[self._get_comparer(xml=condition)] = (combine, sub_filter)
+
+        if len(comparers) == 1 and not next(iter(comparers.values()))[1].ready:
+            # when user has not set an explicit comparer, a single empty 'allow all' comparer is assigned
+            # check for this 'allow all' comparer and remove it if present to speed up comparisons
+            c = next(iter(comparers))
+            if "contains" in c.condition.casefold() and len(c.expected) == 1 and not c.expected[0]:
+                comparers = {}
+
+        filter_include = FilterDefinedList[LocalTrack](values=[path.casefold() for path in include])
+        filter_exclude = FilterDefinedList[LocalTrack](values=[path.casefold() for path in exclude])
+        filter_compare = FilterComparers[LocalTrack](
+            comparers, match_all=self.xml_source["Conditions"]["@CombineMethod"] == "All"
+        )
+
+        filter_include.transform = lambda x: self.path_mapper.map(x, check_existence=False).casefold()
+        filter_exclude.transform = lambda x: self.path_mapper.map(x, check_existence=False).casefold()
+
+        group_by_value = self._pascal_to_snake(self.xml_smart_playlist["@GroupBy"])
+        group_by = None if group_by_value == "track" else TagFields.from_name(group_by_value)[0]
+
+        return FilterMatcher(
+            include=filter_include, exclude=filter_exclude, comparers=filter_compare, group_by=group_by
+        )
+
+    def _get_xml_from_matcher(
+            self, matcher: FilterMatcher, items: list[File], original: list[File | MusifyItem]
+    ) -> Mapping[str, Any]:
+        """
+        Parse the given ``matcher`` to its XML playlist representation.
+
+        :param items: The items to export.
+        :param original: The original items matched from the settings in the original file.
+        :return: A map representing the values to be exported to the XML playlist file.
+        """
+        if not isinstance(matcher.include, FilterDefinedList) and not isinstance(matcher.exclude, FilterDefinedList):
+            matcher.logger.warning(
+                "Cannot export this filter to XML: Include and Exclude settings must both be list filters"
+            )
+            return {}
+
+        items_mapped: Mapping[str, File] = {item.path.casefold(): item for item in items}
+
+        if matcher.comparers:
+            # match again on current conditions to check for differences from original list
+            # which ensures that the paths included in the XML output
+            # do not include paths that match any of the comparer or group_by conditions
+
+            # copy the list of tracks as the sorter will modify the list order
+            original = original.copy()
+            # get the last played track as reference in case comparer is looking for the playing tracks as reference
+            ItemSorter.sort_by_field(original, field=Fields.LAST_PLAYED, reverse=True)
+
+            matched_mapped = {
+                item.path.casefold(): item for item in matcher.comparers(original, reference=original[0])
+            } if matcher.comparers.ready else {}
+            # noinspection PyProtectedMember
+            matched_mapped |= {
+                item.path.casefold(): item for item in matcher._get_group_by_results(original, matched_mapped.values())
+            }
+
+            # get new include/exclude paths based on the leftovers after matching on comparers and group_by settings
+            matcher.exclude.values = list(matched_mapped.keys() - items_mapped)
+            matcher.include.values = [v for v in list(items_mapped - matched_mapped.keys()) if v not in matcher.exclude]
+        else:
+            matched_mapped = items_mapped
+
+        include_items = tuple(items_mapped[path] for path in matcher.include if path in items_mapped)
+        exclude_items = tuple(matched_mapped[path] for path in matcher.exclude if path in matched_mapped)
+
+        source = {}
+        if len(include_items) > 0:  # assign include paths to XML object
+            include_paths = self.path_mapper.unmap_many(include_items, check_existence=False)
+            source["ExceptionsInclude"] = "|".join(include_paths).replace("&", "&amp;")
+        if len(exclude_items) > 0:  # assign exclude paths to XML object
+            exclude_paths = self.path_mapper.unmap_many(exclude_items, check_existence=False)
+            source["Exceptions"] = "|".join(exclude_paths).replace("&", "&amp;")
+
+        return {
+            "SmartPlaylist": {
+                "@GroupBy": matcher.group_by.name.lower() if matcher.group_by else "track",
+                "Source": source,
+            }
+        }
+
+    def get_limiter(self) -> ItemLimiter | None:
+        """Initialise and return a :py:class:`ItemLimiter` object from loaded XML playlist data."""
+        conditions: Mapping[str, str] = self.xml_source["Limit"]
+        if conditions["@Enabled"] != "True":
+            return
+        # filter_duplicates = conditions["@FilterDuplicates"] == "True"
+
+        # MusicBee appears to have some extra allowance on time and byte limits of ~1.25
+        return ItemLimiter(
+            limit=int(conditions["@Count"]),
+            on=LimitType.from_name(conditions["@Type"])[0],
+            sorted_by=conditions["@SelectedBy"],
+            allowance=1.25
+        )
+
+    def _get_xml_from_limiter(self, limiter: ItemLimiter) -> dict[str, Any]:
+        """Parse the given ``limiter`` to its XML playlist representation."""
+
+    def get_sorter(self) -> ItemSorter | None:
+        """Initialise and return a :py:class:`ItemLimiter` object from loaded XML playlist data."""
+        fields: Sequence[Field] | Mapping[Field | bool] = ()
+
+        if "SortBy" in self.xml_source:
+            field_code = int(self.xml_source["SortBy"].get("@Field", 0))
+        elif "DefinedSort" in self.xml_source:
+            field_code = int(self.xml_source["DefinedSort"]["@Id"])
+        else:
+            return
+
+        if field_code in self.custom_sort:
+            fields = self.custom_sort[field_code]
+            return ItemSorter(fields=fields)
+        elif field_code != 78:
+            field = Fields.from_value(field_code)[0]
+
+            if "SortBy" in self.xml_source:
+                fields = {field: self.xml_source["SortBy"]["@Order"] == "Descending"}
+            elif "DefinedSort" in self.xml_source:
+                fields = [field]
+            else:
+                raise NotImplementedError("Sort type in XML not recognised")
+
+        shuffle_mode_value = self._pascal_to_snake(self.xml_smart_playlist["@ShuffleMode"])
+        if not fields and shuffle_mode_value != "none":
+            shuffle_mode = ShuffleMode.from_name(shuffle_mode_value)[0]
+            shuffle_weight = float(self.xml_smart_playlist.get("@ShuffleSameArtistWeight", 0))
+
+            return ItemSorter(fields=fields, shuffle_mode=shuffle_mode, shuffle_weight=shuffle_weight)
+        return ItemSorter(fields=fields or self.custom_sort[6])  # TODO: workaround - see cls.custom_sort
+
+    def _get_xml_from_sorter(self, sorter: ItemSorter) -> dict[str, Any]:
+        """Parse the given ``sorter`` to its XML playlist representation."""
+
+    def as_dict(self):
+        return {"path": self.path, "path_mapper": self.path_mapper}

--- a/musify/libraries/local/track/mp3.py
+++ b/musify/libraries/local/track/mp3.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from musify.core.enum import TagMap
 from musify.file.image import open_image, get_image_bytes
+from musify.libraries.local.exception import TagError
 from musify.libraries.local.track.field import LocalTrackField
 from musify.libraries.local.track.tags.reader import TagReader
 from musify.libraries.local.track.tags.writer import TagWriter
@@ -37,7 +38,7 @@ class MP3TagReader(TagReader[mutagen.mp3.MP3]):
             elif isinstance(value, mutagen.id3.APIC):
                 values.append(value)
             else:
-                raise NotImplementedError(f"Unrecognised id3 type: {value} ({type(value)})")
+                raise TagError(f"Unrecognised id3 type: {value} ({type(value)})")
 
         return values if len(values) > 0 else None
 

--- a/musify/libraries/local/track/tags/writer.py
+++ b/musify/libraries/local/track/tags/writer.py
@@ -36,7 +36,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Remove tags from file.
 
         :param tags: Tags to remove.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: List of tags that have been removed.
         """
         if tags is None or (isinstance(tags, Collection) and len(tags) == 0):
@@ -60,7 +60,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Remove a tag by its tag name.
 
         :param tag_name: Tag name as found in :py:class:`TagMap` to remove.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if tag has been remove, False otherwise.
         """
         removed = False
@@ -93,7 +93,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param tags: The tags to be updated.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -138,7 +138,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
 
         :param tag_id: ID of the tag for this file type.
         :param tag_value: New value to assign.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -159,7 +159,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -175,7 +175,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the title tag from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         return self.write_tag(next(iter(self.tag_map.title), None), track.title, dry_run)
@@ -187,7 +187,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -203,7 +203,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the artist tag from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         return self.write_tag(next(iter(self.tag_map.artist), None), track.artist, dry_run)
@@ -215,7 +215,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -231,7 +231,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the album tag from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         return self.write_tag(next(iter(self.tag_map.album), None), track.album, dry_run)
@@ -245,7 +245,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -261,7 +261,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the album artist tag from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         return self.write_tag(next(iter(self.tag_map.album_artist), None), track.album_artist, dry_run)
@@ -273,7 +273,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -290,7 +290,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the track number and track total tags from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         tag_id_number = next(iter(self.tag_map.track_number), None)
@@ -314,7 +314,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -327,7 +327,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the genre tags from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         return self.write_tag(next(iter(self.tag_map.genres), None), track.genres, dry_run)
@@ -341,7 +341,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -375,7 +375,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the date, year, month, and/or day tags from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True for each updated tag in the order (date, year, month, day)
             if the file has been updated or would have been written when ``dry_run`` is True.
         """
@@ -399,7 +399,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -419,7 +419,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the bpm tag from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         return self.write_tag(next(iter(self.tag_map.bpm), None), track.bpm, dry_run)
@@ -431,7 +431,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -445,7 +445,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the key tag from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         return self.write_tag(next(iter(self.tag_map.key), None), track.key, dry_run)
@@ -457,7 +457,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -474,7 +474,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the disc number and disc total tags from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         tag_id_number = next(iter(self.tag_map.disc_number), None)
@@ -501,7 +501,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -517,7 +517,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the compilation tag from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         return self.write_tag(next(iter(self.tag_map.compilation), None), int(track.compilation), dry_run)
@@ -529,7 +529,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -545,7 +545,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the comments tags from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         return self.write_tag(next(iter(self.tag_map.comments), None), track.comments, dry_run)
@@ -558,7 +558,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Ignored.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -575,7 +575,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the URI tag from ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         tag_id = next(iter(self.tag_map[self.uri_tag.name.lower()]), None)
@@ -589,7 +589,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         :param source: The source track i.e. the track object representing the currently saved file on the drive.
         :param target: The target track i.e. the track object containing new tags with which to update the file.
         :param replace: Destructively overwrite the tag on the file if the ``source`` and ``target`` tags differ.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: The index number of the conditional that was met to warrant updating the file's tags.
             None if none of the conditions were met.
         """
@@ -604,7 +604,7 @@ class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
         Write the images from the ``image_links`` in ``track`` to the stored file.
 
         :param track: The track with the tag to be written.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: True if the file has been updated or would have been written when ``dry_run`` is True.
         """
         raise NotImplementedError

--- a/musify/libraries/local/track/track.py
+++ b/musify/libraries/local/track/track.py
@@ -435,7 +435,7 @@ class LocalTrack[T: mutagen.FileType, U: TagReader, V: TagWriter](LocalItem, Tra
 
         :param tags: Tags to be updated.
         :param replace: Destructively replace tags in each file.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: List of tags that have been updated.
         """
         # reload the mutagen object in place to ensure comparison are being made against current data
@@ -451,7 +451,7 @@ class LocalTrack[T: mutagen.FileType, U: TagReader, V: TagWriter](LocalItem, Tra
         Remove tags from file.
 
         :param tags: Tags to remove.
-        :param dry_run: Run function, but do not modify file at all.
+        :param dry_run: Run function, but do not modify the file on the disk.
         :return: List of tags that have been removed.
         """
         result = self._writer.delete_tags(tags=tags, dry_run=dry_run)

--- a/musify/processors/base.py
+++ b/musify/processors/base.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping, Callable, Collection, Iterable, MutableSequence
 from functools import partial, update_wrapper
-from typing import Any, Self, Optional
+from typing import Any, Optional
 
 from musify.core.printer import PrettyPrinter
 from musify.log.logger import MusifyLogger
@@ -53,28 +53,13 @@ class ItemProcessor(Processor, metaclass=ABCMeta):
     """Base object for processing :py:class:`MusifyItem` objects"""
 
 
-class MusicBeeProcessor(ItemProcessor):
+class MusicBeeProcessor(ItemProcessor, metaclass=ABCMeta):
     """Base object for processing :py:class:`MusifyItem` objects on MusicBee settings"""
 
     @classmethod
     def _processor_method_fmt(cls, name: str) -> str:
         """A custom formatter to apply to the dynamic processor name"""
         return "_" + cls._pascal_to_snake(name)
-
-    @classmethod
-    @abstractmethod
-    def from_xml(cls, xml: Mapping[str, Any], **kwargs) -> Self:
-        """
-        Initialise object from XML playlist data.
-
-        :param xml: The loaded XML object for this playlist.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def to_xml(self, **kwargs) -> Mapping[str, Any]:
-        """Export this object's settings to a map ready for export to an XML playlist file."""
-        raise NotImplementedError
 
 
 # noinspection PyPep8Naming,SpellCheckingInspection

--- a/musify/processors/filter_matcher.py
+++ b/musify/processors/filter_matcher.py
@@ -4,21 +4,15 @@ Processors that filter down objects and data types based on some given configura
 from __future__ import annotations
 
 import logging
-from collections.abc import Collection, Mapping, Callable
+from collections.abc import Collection
 from dataclasses import field, dataclass
 from typing import Any
 
-from musify.core.base import MusifyItem
-from musify.core.enum import Fields, TagField, TagFields
+from musify.core.enum import TagField
 from musify.core.result import Result
-from musify.file.base import File
-from musify.file.path_mapper import PathMapper
 from musify.log.logger import MusifyLogger
 from musify.processors.base import Filter, MusicBeeProcessor, FilterComposite
-from musify.processors.compare import Comparer
 from musify.processors.filter import FilterComparers, FilterDefinedList
-from musify.processors.sort import ItemSorter
-from musify.utils import to_collection
 
 
 @dataclass(frozen=True)
@@ -53,123 +47,6 @@ class FilterMatcher[T: Any, U: Filter, V: Filter, X: FilterComparers](MusicBeePr
     """
 
     __slots__ = ("include", "exclude", "comparers", "group_by")
-
-    @classmethod
-    def from_xml(
-            cls, xml: Mapping[str, Any], path_mapper: PathMapper = PathMapper(), **__
-    ) -> FilterMatcher[str, FilterDefinedList[str], FilterDefinedList[str], FilterComparers[str]]:
-        """
-        Initialise object from XML playlist.
-
-        :param xml: The loaded XML object for this playlist.
-        :param path_mapper: Optionally, provide a :py:class:`PathMapper` for paths stored in the playlist file.
-            Useful if the playlist file contains relative paths and/or paths for other systems that need to be
-            mapped to absolute, system-specific paths to be loaded and back again when saved.
-        """
-        source = xml["SmartPlaylist"]["Source"]
-
-        # tracks to include/exclude even if they meet/don't meet match compare conditions
-        include_str: str = source.get("ExceptionsInclude") or ""
-        include = path_mapper.map_many(set(include_str.split("|")), check_existence=True)
-        exclude_str: str = source.get("Exceptions") or ""
-        exclude = path_mapper.map_many(set(exclude_str.split("|")), check_existence=True)
-
-        conditions = xml["SmartPlaylist"]["Source"]["Conditions"]
-        comparers: dict[Comparer, tuple[bool, FilterComparers]] = {}
-        for condition in to_collection(conditions["Condition"]):
-            if any(key in condition for key in {"And", "Or"}):
-                sub_combine = "And" in condition
-                sub_conditions = condition["And" if sub_combine else "Or"]
-                sub_comparers = [Comparer.from_xml(sub) for sub in to_collection(sub_conditions["Condition"])]
-                sub_filter = FilterComparers(
-                    comparers=sub_comparers, match_all=sub_conditions["@CombineMethod"] == "All"
-                )
-            else:
-                sub_combine = False
-                sub_filter = FilterComparers()
-
-            comparers[Comparer.from_xml(xml=condition)] = (sub_combine, sub_filter)
-
-        if len(comparers) == 1 and not next(iter(comparers.values()))[1].ready:
-            # when user has not set an explicit comparer, a single empty 'allow all' comparer is assigned
-            # check for this 'allow all' comparer and remove it if present to speed up comparisons
-            c = next(iter(comparers))
-            if "contains" in c.condition.casefold() and len(c.expected) == 1 and not c.expected[0]:
-                comparers = {}
-
-        filter_include = FilterDefinedList(values=[path.casefold() for path in include])
-        filter_exclude = FilterDefinedList(values=[path.casefold() for path in exclude])
-        filter_compare = FilterComparers(comparers, match_all=conditions["@CombineMethod"] == "All")
-
-        filter_include.transform = lambda x: path_mapper.map(x, check_existence=False).casefold()
-        filter_exclude.transform = lambda x: path_mapper.map(x, check_existence=False).casefold()
-
-        group_by_value = cls._pascal_to_snake(xml["SmartPlaylist"]["@GroupBy"])
-        group_by = None if group_by_value == "track" else TagFields.from_name(group_by_value)[0]
-
-        return cls(include=filter_include, exclude=filter_exclude, comparers=filter_compare, group_by=group_by)
-
-    def to_xml(
-            self,
-            items: list[File],
-            original: list[File | MusifyItem],
-            path_mapper: Callable[[Collection[str | File]], Collection[str]] = lambda x: x,
-            **__
-    ) -> Mapping[str, Any]:
-        """
-        Export this object's include and exclude filters to a map ready for export to an XML playlist file.
-
-        :param items: The items to export.
-        :param original: The original items matched from the settings in the original file.
-        :param path_mapper: A mapper to apply for paths before formatting to a string value for the XML-like output.
-        :return: A map representing the values to be exported to the XML playlist file.
-        """
-        if not isinstance(self.include, FilterDefinedList) and not isinstance(self.exclude, FilterDefinedList):
-            self.logger.warning(
-                "Cannot export this filter to XML: Include and Exclude settings must both be list filters"
-            )
-            return {}
-
-        items_mapped: Mapping[str, File] = {item.path.casefold(): item for item in items}
-
-        if self.comparers:
-            # match again on current conditions to check for differences from original list
-            # which ensures that the paths included in the XML output
-            # do not include paths that match any of the comparer or group_by conditions
-
-            # copy the list of tracks as the sorter will modify the list order
-            original = original.copy()
-            # get the last played track as reference in case comparer is looking for the playing tracks as reference
-            ItemSorter.sort_by_field(original, field=Fields.LAST_PLAYED, reverse=True)
-
-            matched_mapped = {
-                item.path.casefold(): item for item in self.comparers(original, reference=original[0])
-            } if self.comparers.ready else {}
-            matched_mapped |= {
-                item.path.casefold(): item for item in self._get_group_by_results(original, matched_mapped.values())
-            }
-
-            # get new include/exclude paths based on the leftovers after matching on comparers and group_by settings
-            self.exclude.values = list(matched_mapped.keys() - items_mapped)
-            self.include.values = [v for v in list(items_mapped - matched_mapped.keys()) if v not in self.exclude]
-        else:
-            matched_mapped = items_mapped
-
-        include_items = tuple(items_mapped[path] for path in self.include if path in items_mapped)
-        exclude_items = tuple(matched_mapped[path] for path in self.exclude if path in matched_mapped)
-
-        source = {}
-        if len(include_items) > 0:  # assign include paths to XML object
-            source["ExceptionsInclude"] = "|".join(path_mapper(include_items)).replace("&", "&amp;")
-        if len(exclude_items) > 0:  # assign exclude paths to XML object
-            source["Exceptions"] = "|".join(path_mapper(exclude_items)).replace("&", "&amp;")
-
-        return {
-            "SmartPlaylist": {
-                "@GroupBy": self.group_by.name.lower() if self.group_by else "track",
-                "Source": source,
-            }
-        }
 
     def __init__(
             self,

--- a/musify/processors/limit.py
+++ b/musify/processors/limit.py
@@ -1,11 +1,10 @@
 """
 Processor that limits the items in a given collection of items
 """
-from collections.abc import Collection, Mapping
+from collections.abc import Collection
 from functools import reduce
 from operator import mul
 from random import shuffle
-from typing import Any, Self
 
 from musify.core.base import MusifyItem
 from musify.core.enum import MusifyEnum, Fields
@@ -57,24 +56,6 @@ class ItemLimiter(MusicBeeProcessor, DynamicProcessor):
     def limit_sort(self) -> str | None:
         """String representation of the sorting method to use before limiting"""
         return self._processor_name.lstrip("_")
-
-    @classmethod
-    def from_xml(cls, xml: Mapping[str, Any], **__) -> Self | None:
-        conditions: Mapping[str, str] = xml["SmartPlaylist"]["Source"]["Limit"]
-        if conditions["@Enabled"] != "True":
-            return
-        # filter_duplicates = conditions["@FilterDuplicates"] == "True"
-
-        # MusicBee appears to have some extra allowance on time and byte limits of ~1.25
-        return cls(
-            limit=int(conditions["@Count"]),
-            on=LimitType.from_name(conditions["@Type"])[0],
-            sorted_by=conditions["@SelectedBy"],
-            allowance=1.25
-        )
-
-    def to_xml(self, **kwargs) -> Mapping[str, Any]:
-        raise NotImplementedError
 
     def __init__(
             self,

--- a/musify/processors/sort.py
+++ b/musify/processors/sort.py
@@ -118,8 +118,8 @@ class ItemSorter(MusicBeeProcessor):
     ):
         super().__init__()
         fields = to_collection(fields, list) if isinstance(fields, Field) else fields
-        self.sort_fields: Mapping[Field | None, bool]
-        self.sort_fields = {field: False for field in fields} if isinstance(fields, Sequence) else fields
+        self.sort_fields: Mapping[Field | None, bool] = {field: False for field in fields} \
+            if isinstance(fields, Sequence) else fields
 
         self.shuffle_mode = shuffle_mode
         self.shuffle_weight = limit_value(shuffle_weight, floor=-1, ceil=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Natural Language :: English",
     "Intended Audience :: Developers",
     "Intended Audience :: End Users/Desktop",

--- a/tests/__resources/playlist/Complex Match.xautopf
+++ b/tests/__resources/playlist/Complex Match.xautopf
@@ -18,7 +18,7 @@
       </Condition>
     </Conditions>
     <Limit FilterDuplicates="False" Enabled="True" Count="1" Type="Seconds" SelectedBy="MostRecentlyAdded" />
-    <SortBy Field="86" Order="Ascending" />
+    <DefinedSort Id="6" />
     <Fields>
       <Group Id="TrackDetail">
         <Field Code="20" Width="24" />

--- a/tests/libraries/local/playlist/test_xautopf.py
+++ b/tests/libraries/local/playlist/test_xautopf.py
@@ -356,6 +356,29 @@ class TestXMLPlaylistParser(PrettyPrinterTester):
 
         assert matcher.group_by == Fields.ALBUM
 
+    def test_parse_matcher(self):
+        parser_initial = XMLPlaylistParser(path=path_playlist_xautopf_ra)
+        parser_final = XMLPlaylistParser(path=path_playlist_xautopf_cm)
+        initial = parser_initial.get_matcher()
+        final = parser_final.get_matcher()
+
+        assert initial.group_by != final.group_by
+        assert initial.comparers.ready != final.comparers.ready
+        assert len(initial.comparers.comparers) != len(final.comparers.comparers)
+
+        # default values cause getter to return default, non-ready processor
+        parser_initial.parse_matcher()
+        assert not parser_initial.get_matcher().ready
+
+        parser_initial.parse_matcher(final)
+        new = parser_initial.get_matcher()
+        assert new.group_by == final.group_by
+        assert new.comparers.ready == final.comparers.ready
+        assert len(new.comparers.comparers) == len(final.comparers.comparers)
+
+        assert parser_initial.xml_smart_playlist["@GroupBy"] == parser_final.xml_smart_playlist["@GroupBy"]
+        assert parser_initial.xml_source["Conditions"] == parser_final.xml_source["Conditions"]
+
     ###########################################################################
     ## ItemLimiter parsing
     ###########################################################################
@@ -386,7 +409,6 @@ class TestXMLPlaylistParser(PrettyPrinterTester):
         assert parser_initial.get_limiter() is None
 
         parser_initial.parse_limiter(final)
-
         new = parser_initial.get_limiter()
         assert new is not None
         assert new.limit_max == final.limit_max
@@ -441,7 +463,6 @@ class TestXMLPlaylistParser(PrettyPrinterTester):
         assert final.sort_fields == parser_final.defined_sort[6]
 
         parser_initial.parse_sorter(final)
-
         new = parser_initial.get_sorter()
         assert initial.sort_fields != new.sort_fields == final.sort_fields
 
@@ -463,7 +484,6 @@ class TestXMLPlaylistParser(PrettyPrinterTester):
         assert parser_initial.get_sorter().shuffle_mode is None
 
         parser_initial.parse_sorter(final)
-
         new = parser_initial.get_sorter()
         assert initial.sort_fields != new.sort_fields == final.sort_fields
 
@@ -486,7 +506,6 @@ class TestXMLPlaylistParser(PrettyPrinterTester):
         assert actual_weight != parser_final.xml_smart_playlist["@ShuffleSameArtistWeight"]
 
         parser_initial.parse_sorter(final)
-
         new = parser_initial.get_sorter()
         assert initial.shuffle_mode != new.shuffle_mode == final.shuffle_mode
         assert initial.shuffle_weight != new.shuffle_weight == final.shuffle_weight

--- a/tests/libraries/local/playlist/test_xautopf.py
+++ b/tests/libraries/local/playlist/test_xautopf.py
@@ -196,6 +196,21 @@ class TestXMLPlaylistParser(PrettyPrinterTester):
         """Yields a :py:class:`PathMapper` that can map paths from the test playlist files"""
         yield PathStemMapper(stem_map={"../": path_resources}, available_paths=path_track_all)
 
+    @pytest.mark.parametrize("path", [path_playlist_xautopf_bp], indirect=["path"])
+    def test_save(self, path: str):
+        parser = XMLPlaylistParser(path=path)
+
+        description = "i am a brand new description"
+        parser.description = description
+        parser.save()
+        parser.load()
+        assert parser.description != description
+
+        parser.description = description
+        parser.save(dry_run=False)
+        parser.load()
+        assert parser.description == description
+
     ###########################################################################
     ## Comparer parsing
     ###########################################################################

--- a/tests/processors/test_compare.py
+++ b/tests/processors/test_compare.py
@@ -1,17 +1,14 @@
 from datetime import datetime, date, timedelta
 
 import pytest
-import xmltodict
 
 from musify.field import TrackField
 from musify.libraries.local.track import MP3, M4A, FLAC
 from musify.libraries.local.track.field import LocalTrackField
 from musify.processors.compare import Comparer
 from musify.processors.exception import ComparerError, ProcessorLookupError
-from musify.utils import to_collection
 from tests.core.printer import PrettyPrinterTester
 from tests.libraries.local.track.utils import random_track
-from tests.libraries.local.utils import path_playlist_xautopf_bp, path_playlist_xautopf_ra
 
 
 class TestComparer(PrettyPrinterTester):
@@ -179,51 +176,3 @@ class TestComparer(PrettyPrinterTester):
         test_truncated = datetime.now().replace(second=0, microsecond=0) - timedelta(hours=8)
         assert exp_truncated == test_truncated
         assert comparer._converted
-
-    ###########################################################################
-    ## XML I/O
-    ###########################################################################
-    def test_from_xml_bp(self):
-        with open(path_playlist_xautopf_bp, "r", encoding="utf-8") as f:
-            xml = xmltodict.parse(f.read())
-
-        conditions = xml["SmartPlaylist"]["Source"]["Conditions"]
-        comparers = [Comparer.from_xml(xml=condition) for condition in to_collection(conditions["Condition"])]
-        assert len(comparers) == 3
-
-        assert comparers[0].field == LocalTrackField.ALBUM
-        assert not comparers[0]._converted
-        assert comparers[0].expected == ["an album"]
-        assert comparers[0].condition == "contains"
-        assert comparers[0]._processor_method == comparers[0]._contains
-
-        assert comparers[1].field == LocalTrackField.ARTIST
-        assert not comparers[1]._converted
-        assert comparers[1].expected is None
-        assert comparers[1].condition == "is_null"
-        assert comparers[1]._processor_method == comparers[1]._is_null
-
-        assert comparers[2].field == LocalTrackField.TRACK_NUMBER
-        assert not comparers[2]._converted
-        assert comparers[2].expected == ["30"]
-        assert comparers[2].condition == "less_than"
-        assert comparers[2]._processor_method == comparers[2]._is_before
-
-    def test_from_xml_ra(self):
-        with open(path_playlist_xautopf_ra, "r", encoding="utf-8") as f:
-            xml = xmltodict.parse(f.read())
-
-        conditions = xml["SmartPlaylist"]["Source"]["Conditions"]
-        comparers = [Comparer.from_xml(xml=condition) for condition in to_collection(conditions["Condition"])]
-        assert len(comparers) == 1
-        comparer = comparers[0]
-
-        assert comparer.field == LocalTrackField.ALBUM
-        assert not comparer._converted
-        assert comparer.expected == [""]
-        assert comparer.condition == "contains"
-        assert comparer._processor_method == comparer._contains
-
-    @pytest.mark.skip(reason="not implemented yet")
-    def test_to_xml(self):
-        pass

--- a/tests/processors/test_limit.py
+++ b/tests/processors/test_limit.py
@@ -2,13 +2,11 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-import xmltodict
 
 from musify.libraries.local.track import LocalTrack
 from musify.processors.limit import ItemLimiter, LimitType
 from tests.core.printer import PrettyPrinterTester
 from tests.libraries.local.track.utils import random_tracks
-from tests.libraries.local.utils import path_playlist_xautopf_bp, path_playlist_xautopf_ra
 from tests.utils import random_file
 
 
@@ -119,25 +117,3 @@ class TestItemLimiter(PrettyPrinterTester):
         limiter = ItemLimiter(limit=30, on=LimitType.KILOBYTES, allowance=2)
         limiter.limit(tracks)
         assert len(tracks) == 21
-
-    ###########################################################################
-    ## XML I/O
-    ###########################################################################
-    def test_from_xml_bp(self):
-        with open(path_playlist_xautopf_bp, "r", encoding="utf-8") as f:
-            xml = xmltodict.parse(f.read())
-        assert ItemLimiter.from_xml(xml=xml) is None
-
-    def test_from_xml_ra(self):
-        with open(path_playlist_xautopf_ra, "r", encoding="utf-8") as f:
-            xml = xmltodict.parse(f.read())
-        limiter = ItemLimiter.from_xml(xml=xml)
-
-        assert limiter.limit_max == 20
-        assert limiter.kind == LimitType.ITEMS
-        assert limiter.allowance == 1.25
-        assert limiter._processor_method == limiter._most_recently_added
-
-    @pytest.mark.skip(reason="not implemented yet")
-    def test_to_xml(self):
-        pass

--- a/tests/processors/test_sort.py
+++ b/tests/processors/test_sort.py
@@ -3,9 +3,7 @@ from itertools import groupby
 from random import choice, randrange
 
 import pytest
-import xmltodict
 
-from musify.core.enum import Fields
 from musify.field import TrackField
 from musify.libraries.local.track import LocalTrack
 from musify.libraries.local.track.field import LocalTrackField
@@ -13,7 +11,6 @@ from musify.processors.sort import ItemSorter, ShuffleMode
 from musify.utils import strip_ignore_words
 from tests.core.printer import PrettyPrinterTester
 from tests.libraries.local.track.utils import random_tracks
-from tests.libraries.local.utils import path_playlist_xautopf_bp, path_playlist_xautopf_ra
 
 
 class TestItemSorter(PrettyPrinterTester):
@@ -103,44 +100,3 @@ class TestItemSorter(PrettyPrinterTester):
         sorter = ItemSorter(fields=fields)
         sorter(tracks)
         assert tracks == tracks_sorted
-
-    ###########################################################################
-    ## XML I/O
-    ###########################################################################
-    def test_from_xml_bp(self):
-        with open(path_playlist_xautopf_bp, "r", encoding="utf-8") as f:
-            xml = xmltodict.parse(f.read())
-
-        # shuffle settings not set as automatic order defined
-        sorter = ItemSorter.from_xml(xml=xml)
-        assert sorter.sort_fields == {Fields.TRACK_NUMBER: False}
-        assert sorter.shuffle_mode is None
-        assert sorter.shuffle_weight == 0.0
-
-        # flip sorting to manual order to force function to set shuffle settings
-        xml["SmartPlaylist"]["Source"]["SortBy"]["@Field"] = "78"
-        sorter = ItemSorter.from_xml(xml=xml)
-        assert sorter.sort_fields == {}
-        assert sorter.shuffle_mode == ShuffleMode.RECENT_ADDED
-        assert sorter.shuffle_weight == 0.5
-
-    def test_from_xml_ra(self):
-        with open(path_playlist_xautopf_ra, "r", encoding="utf-8") as f:
-            xml = xmltodict.parse(f.read())
-
-        # shuffle settings not set as automatic order defined
-        sorter = ItemSorter.from_xml(xml=xml)
-        assert sorter.sort_fields == {Fields.DATE_ADDED: True}
-        assert sorter.shuffle_mode is None
-        assert sorter.shuffle_weight == 0.0
-
-        # flip sorting to manual order to force function to set shuffle settings
-        xml["SmartPlaylist"]["Source"]["SortBy"]["@Field"] = "78"
-        sorter = ItemSorter.from_xml(xml=xml)
-        assert sorter.sort_fields == {}
-        assert sorter.shuffle_mode == ShuffleMode.DIFFERENT_ARTIST
-        assert sorter.shuffle_weight == -0.2
-
-    @pytest.mark.skip(reason="not implemented yet")
-    def test_to_xml(self):
-        pass


### PR DESCRIPTION
Added
-----

* Now fully supports parsing of processors relating to XAutoPF objects with full I/O of settings
  to/from their related XML files on disk.
* Now supports creating new XAutoPF files from scratch without the file needing to already exist.
  For XML values not directly controlled by Musify, users can use the 'default_xml' class attribute
  to control the initial default values applied in this scenario.

Changed
-------

* Removed ``from_xml`` and ``to_xml`` methods from all :py:class:`.MusicBeeProcessor` subclasses.
  Moved this logic to :py:class:`.XMLPlaylistParser` as distinct 'get' methods for each processor type.
* Moved loading of XML file logic from :py:class:`.XAutoPF` to :py:class:`.XMLPlaylistParser`.
  :py:class:`.XMLPlaylistParser` is now solely responsible for all XML parsing and handling for XAutoPF files