### PR TITLE
add more concurrency + remove get_filtered_playlists method

### DIFF
--- a/docs/_howto/scripts/local.library.backup-restore.py
+++ b/docs/_howto/scripts/local.library.backup-restore.py
@@ -28,4 +28,4 @@ tags = [
 library.restore_tracks(tracks, tags=tags)
 
 results = library.save_tracks(tags=tags, replace=True, dry_run=False)
-library.log_sync_result(results)
+library.log_save_tracks_result(results)

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -54,7 +54,15 @@ Changed
 -------
 
 * Major refactoring and restructuring to all modules to improve modularity and add composition
-* :py:meth:`.LocalLibrary.load_tracks` and :py:meth:`.LocalLibrary.load_playlists` now run concurrently
+* The following classes and methods have been modified to implement concurrency to improve performance:
+   * :py:meth:`.LocalLibrary.load_tracks`
+   * :py:meth:`.LocalLibrary.save_tracks`
+   * :py:meth:`.LocalLibrary.load_playlists`
+   * :py:meth:`.LocalLibrary.save_playlists`
+   * :py:meth:`.LocalLibrary.json` + optimisation for extracting JSON data from tracks
+   * :py:class:`.ItemMatcher`
+   * :py:class:`.RemoteItemChecker`
+   * :py:class:`.RemoteItemSearcher`
 * Made :py:func:`.load_tracks` and :py:func:`.load_playlists` utility functions more DRY
 * Move :py:meth:`.TagReader.load` from :py:class:`.LocalTrack` to super class :py:class:`.TagReader`
 * :py:meth:`.SpotifyAPI.extend_items` now skips on responses that are already fully extended
@@ -83,7 +91,9 @@ Removed
 -------
 
 * Redundant ShuffleBy enum and related arguments from :py:class:`.ItemSorter`
-* `ItemProcessor` and `MusicBeeProcessor` abstraction layers. No longer needed after some refactoring
+* ``ItemProcessor`` and ``MusicBeeProcessor`` abstraction layers. No longer needed after some refactoring
+* ``get_filtered_playlists`` method from :py:class:`.Library`.
+  This contained author specific logic and was not appropriate for general use
 
 Documentation
 -------------

--- a/musify/core/printer.py
+++ b/musify/core/printer.py
@@ -46,6 +46,7 @@ class PrettyPrinter(ABC):
         """Return a dictionary representation of the key attributes of this object that is safe to output to JSON"""
         return self._to_json(self.as_dict())
 
+    # TODO: this runs very slowly when getting library JSON. Add ThreadPoolExecutor here?
     @classmethod
     def _to_json(cls, attributes: JSON) -> DictJSON:
         result: DictJSON = {}

--- a/musify/core/printer.py
+++ b/musify/core/printer.py
@@ -4,10 +4,11 @@ The fundamental core printer classes for the entire package.
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, date
 from typing import Any
 
-from musify.types import UnitIterable, JSON, DictJSON
+from musify.types import UnitIterable, JSON, DictJSON, JSON_VALUE
 from musify.utils import to_collection
 
 
@@ -42,39 +43,47 @@ class PrettyPrinter(ABC):
         """
         raise NotImplementedError
 
+    def _json_attributes(self):
+        return self.as_dict()
+
     def json(self) -> DictJSON:
         """Return a dictionary representation of the key attributes of this object that is safe to output to JSON"""
-        return self._to_json(self.as_dict())
+        return self._to_json(self._json_attributes())
 
-    # TODO: this runs very slowly when getting library JSON. Add ThreadPoolExecutor here?
     @classmethod
-    def _to_json(cls, attributes: JSON) -> DictJSON:
-        result: DictJSON = {}
+    def _to_json(cls, attributes: JSON, pool: bool = False) -> dict[str, JSON_VALUE]:
+        def _get_json_key_value(attribute: tuple[Any, Any]) -> tuple[str, JSON_VALUE | list[Future[JSON_VALUE]]]:
+            key, value = attribute
+            return str(key), cls._get_json_value(value=value)
 
-        for attr_key, attr_val in attributes.items():
-            attr_key = str(attr_key)
-            if isinstance(attr_val, set):
-                attr_val = to_collection(attr_val)
+        if not pool:
+            tasks = map(_get_json_key_value, attributes.items())
+        else:
+            with ThreadPoolExecutor(thread_name_prefix="to-json") as executor:
+                tasks = executor.map(_get_json_key_value, attributes.items())
 
-            if isinstance(attr_val, (list, tuple)):
-                result[attr_key] = []
-                for item in attr_val:
-                    if isinstance(item, PrettyPrinter):
-                        result[attr_key].append(item.json())
-                    elif isinstance(item, (datetime, date)):
-                        result[attr_key].append(str(item))
-                    else:
-                        result[attr_key].append(item)
-            elif isinstance(attr_val, Mapping):
-                result[attr_key] = cls._to_json(attr_val)
-            elif isinstance(attr_val, PrettyPrinter):
-                result[attr_key] = attr_val.json()
-            elif isinstance(attr_val, (datetime, date)):
-                result[attr_key] = str(attr_val)
+        return dict(tasks)
+
+    @classmethod
+    def _get_json_value(cls, value: Any, pool: bool = False) -> JSON_VALUE | list[Future[JSON_VALUE]]:
+        if isinstance(value, set):
+            value = to_collection(value)
+
+        if isinstance(value, (list, tuple)):
+            if not pool:
+                tasks = map(cls._get_json_value, value)
             else:
-                result[attr_key] = attr_val
+                with ThreadPoolExecutor(thread_name_prefix="to-json-value") as executor:
+                    tasks = executor.map(cls._get_json_value, value)
+            return list(tasks)
+        elif isinstance(value, Mapping):
+            return cls._to_json(value, pool=pool)
+        elif isinstance(value, PrettyPrinter):
+            return value._to_json(value._json_attributes(), pool=pool)
+        elif isinstance(value, (datetime, date)):
+            return str(value)
 
-        return result
+        return value
 
     def __str__(self, indent: int = 2, increment: int = 2):
         obj_dict = self.as_dict()

--- a/musify/libraries/core/collection.py
+++ b/musify/libraries/core/collection.py
@@ -261,8 +261,8 @@ class MusifyCollection[T: MusifyItem](MusifyObject, MutableSequence[T], metaclas
     def as_dict(self):
         return self._condense_attributes(self._get_attributes())
 
-    def json(self):
-        return self._to_json(self._get_attributes())
+    def _json_attributes(self):
+        return self._get_attributes()
 
     def __eq__(self, __collection: MusifyCollection | Iterable[T]):
         """Names equal and all items equal in order"""

--- a/musify/libraries/core/object.py
+++ b/musify/libraries/core/object.py
@@ -369,6 +369,7 @@ class Library[T: Track](MusifyCollection[T], metaclass=ABCMeta):
             pl for name, pl in self.playlists.items() if not playlist_filter or name in playlist_filter(self.playlists)
         ]
 
+        # TODO: this runs very slowly in production. Add ThreadPoolExecutor here?
         max_width = get_max_width(self.playlists)
         filtered: dict[str, Playlist[T]] = {}
         for pl in self.logger.get_progress_bar(iterable=pl_filtered, desc="Filtering playlists", unit="playlists"):

--- a/musify/libraries/core/object.py
+++ b/musify/libraries/core/object.py
@@ -16,9 +16,6 @@ from musify.libraries.core.collection import MusifyCollection
 from musify.libraries.remote.core.enum import RemoteObjectType
 from musify.libraries.remote.core.processors.wrangle import RemoteDataWrangler
 from musify.log.logger import MusifyLogger
-from musify.processors.base import Filter
-from musify.processors.filter import FilterDefinedList
-from musify.utils import align_string, get_max_width
 
 
 class Track(MusifyItem, metaclass=ABCMeta):
@@ -343,54 +340,6 @@ class Library[T: Track](MusifyCollection[T], metaclass=ABCMeta):
         # noinspection PyTypeChecker
         #: The :py:class:`MusifyLogger` for this  object
         self.logger: MusifyLogger = logging.getLogger(__name__)
-
-    def get_filtered_playlists(
-            self, playlist_filter: Collection[str] | Filter[str] = (), **tag_filter: dict[str, tuple[str, ...]]
-    ) -> dict[str, Playlist[T]]:
-        """
-        Returns a filtered set of playlists in this library.
-        The playlists returned are deep copies of the playlists in the library.
-
-        :param playlist_filter: An optional :py:class:`Filter` to apply or collection of playlist names.
-            Playlist names will be passed to this filter to limit which playlists are processed.
-        :param tag_filter: Provide optional kwargs of the tags and values of items to filter out of every playlist.
-            Parse a tag name as a parameter, any item matching the values given for this tag will be filtered out.
-            NOTE: Only `string` value types are currently supported.
-        :return: Filtered playlists.
-        """
-        self.logger.info(
-            f"\33[1;95m ->\33[1;97m Filtering playlists and tracks from {len(self.playlists)} playlists\n"
-            f"\33[0;90m    Filter out tags: {tag_filter} \33[0m"
-        )
-
-        if not isinstance(playlist_filter, Filter):
-            playlist_filter = FilterDefinedList(playlist_filter)
-        pl_filtered = [
-            pl for name, pl in self.playlists.items() if not playlist_filter or name in playlist_filter(self.playlists)
-        ]
-
-        # TODO: this runs very slowly in production. Add ThreadPoolExecutor here?
-        max_width = get_max_width(self.playlists)
-        filtered: dict[str, Playlist[T]] = {}
-        for pl in self.logger.get_progress_bar(iterable=pl_filtered, desc="Filtering playlists", unit="playlists"):
-            filtered[pl.name] = deepcopy(pl)
-            for track in pl.tracks:
-                for tag, values in tag_filter.items():
-                    item_val = track[tag]
-                    if not isinstance(item_val, str):
-                        continue
-
-                    if any(v.strip().casefold() in item_val.strip().casefold() for v in values):
-                        filtered[pl.name].remove(track)
-                        break
-
-            self.logger.debug(
-                f"{align_string(pl.name, max_width=max_width)} | "
-                f"Filtered out {len(pl) - len(filtered[pl.name]):>3} items"
-            )
-
-        self.logger.print()
-        return filtered
 
     @abstractmethod
     def load(self):

--- a/musify/libraries/local/collection.py
+++ b/musify/libraries/local/collection.py
@@ -111,9 +111,9 @@ class LocalCollection[T: LocalTrack](MusifyCollection[T], metaclass=ABCMeta):
                 track: executor.submit(track.save, tags=tags, replace=replace, dry_run=dry_run)
                 for track in self.tracks
             }
-            bar = self.logger.get_progress_bar(futures, desc="Updating tracks", unit="tracks", total=len(self.tracks))
+            bar = self.logger.get_progress_bar(futures.items(), desc="Updating tracks", unit="tracks")
 
-            return {track: future.result() for track, future in dict(bar).items() if future.result().updated}
+            return {track: future.result() for track, future in bar if future.result().updated}
 
     def log_save_tracks_result(self, results: Mapping[LocalTrack, SyncResultTrack]) -> None:
         """Log stats from the results of a ``save_tracks`` operation"""

--- a/musify/libraries/local/collection.py
+++ b/musify/libraries/local/collection.py
@@ -113,7 +113,7 @@ class LocalCollection[T: LocalTrack](MusifyCollection[T], metaclass=ABCMeta):
             }
             bar = self.logger.get_progress_bar(futures, desc="Updating tracks", unit="tracks", total=len(self.tracks))
 
-            return {track: future.result() for track, future in bar if future.result().updated}
+            return {track: future.result() for track, future in dict(bar).items() if future.result().updated}
 
     def log_save_tracks_result(self, results: Mapping[LocalTrack, SyncResultTrack]) -> None:
         """Log stats from the results of a ``save_tracks`` operation"""

--- a/musify/libraries/local/collection.py
+++ b/musify/libraries/local/collection.py
@@ -102,6 +102,7 @@ class LocalCollection[T: LocalTrack](MusifyCollection[T], metaclass=ABCMeta):
         #: The :py:class:`MusifyLogger` for this  object
         self.logger: MusifyLogger = logging.getLogger(__name__)
 
+    # TODO: Add ThreadPoolExecutor here?
     def save_tracks(
             self,
             tags: UnitIterable[LocalTrackField] = LocalTrackField.ALL,

--- a/musify/libraries/local/collection.py
+++ b/musify/libraries/local/collection.py
@@ -7,6 +7,7 @@ import logging
 import sys
 from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping, Collection, Iterable, Container
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from glob import glob
 from os.path import splitext, join, basename, exists, isdir
@@ -56,20 +57,9 @@ class LocalCollection[T: LocalTrack](MusifyCollection[T], metaclass=ABCMeta):
         raise NotImplementedError
 
     @property
-    def artists(self) -> list[str]:
-        """List of artists ordered by frequency of appearance on the tracks in this collection"""
-        return get_most_common_values(track.artist for track in self.tracks if track.artist)
-
-    @property
     def track_total(self) -> int:
         """The total number of tracks in this collection"""
         return len(self)
-
-    @property
-    def genres(self) -> list[str]:
-        """List of genres ordered by frequency of appearance on the tracks in this collection"""
-        genres = (genre for track in self.tracks for genre in (track.genres if track.genres else []))
-        return get_most_common_values(genres)
 
     @property
     def last_modified(self) -> datetime:
@@ -102,7 +92,6 @@ class LocalCollection[T: LocalTrack](MusifyCollection[T], metaclass=ABCMeta):
         #: The :py:class:`MusifyLogger` for this  object
         self.logger: MusifyLogger = logging.getLogger(__name__)
 
-    # TODO: Add ThreadPoolExecutor here?
     def save_tracks(
             self,
             tags: UnitIterable[LocalTrackField] = LocalTrackField.ALL,
@@ -117,11 +106,16 @@ class LocalCollection[T: LocalTrack](MusifyCollection[T], metaclass=ABCMeta):
         :param dry_run: Run function, but do not modify the file on the disk.
         :return: A map of the :py:class:`LocalTrack` saved to its result as a :py:class:`SyncResultTrack` object
         """
-        bar = self.logger.get_progress_bar(iterable=self.tracks, desc="Updating tracks", unit="tracks")
-        results = {track: track.save(tags=tags, replace=replace, dry_run=dry_run) for track in bar}
-        return {track: result for track, result in results.items() if result.updated}
+        with ThreadPoolExecutor(thread_name_prefix="track-saver") as executor:
+            futures = {
+                track: executor.submit(track.save, tags=tags, replace=replace, dry_run=dry_run)
+                for track in self.tracks
+            }
+            bar = self.logger.get_progress_bar(futures, desc="Updating tracks", unit="tracks", total=len(self.tracks))
 
-    def log_sync_result(self, results: Mapping[LocalTrack, SyncResultTrack]) -> None:
+            return {track: future.result() for track, future in bar if future.result().updated}
+
+    def log_save_tracks_result(self, results: Mapping[LocalTrack, SyncResultTrack]) -> None:
         """Log stats from the results of a ``save_tracks`` operation"""
         if not results:
             return
@@ -197,6 +191,17 @@ class LocalCollectionFiltered[T: LocalItem](LocalCollection[T], metaclass=ABCMet
     @property
     def tracks(self):
         return self._tracks
+
+    @property
+    def artists(self) -> list[str]:
+        """List of artists ordered by frequency of appearance on the tracks in this collection"""
+        return get_most_common_values(track.artist for track in self.tracks if track.artist)
+
+    @property
+    def genres(self) -> list[str]:
+        """List of genres ordered by frequency of appearance on the tracks in this collection"""
+        genres = (genre for track in self.tracks for genre in (track.genres if track.genres else []))
+        return get_most_common_values(genres)
 
     def __init__(
             self, tracks: Collection[LocalTrack], name: str | None = None, remote_wrangler: RemoteDataWrangler = None

--- a/musify/libraries/local/library/library.py
+++ b/musify/libraries/local/library/library.py
@@ -385,9 +385,9 @@ class LocalLibrary(LocalCollection[LocalTrack], Library[LocalTrack]):
         """
         with ThreadPoolExecutor(thread_name_prefix="playlist-saver") as executor:
             futures = {name: executor.submit(pl.save, dry_run=dry_run) for name, pl in self.playlists.items()}
-            bar = self.logger.get_progress_bar(futures, desc="Updating playlists", unit="playlists")
+            bar = self.logger.get_progress_bar(futures.items(), desc="Updating playlists", unit="playlists")
 
-        return dict(bar)
+            return dict(bar)
 
     ###########################################################################
     ## Backup/restore

--- a/musify/libraries/remote/core/api.py
+++ b/musify/libraries/remote/core/api.py
@@ -149,7 +149,7 @@ class RemoteAPI(ABC):
         valid_types_responses = all(isinstance(item, MutableMapping) for item in responses)
         valid_lengths = len(original) == len(responses)
         if not all((valid_types_input, valid_types_responses, valid_lengths)):
-            self.logger.warning(
+            self.logger.debug(
                 "Could not merge responses to given user input | "
                 "Reason: assertions failed | "
                 f"{valid_types_input=} {valid_types_responses=} {valid_lengths=} | "
@@ -160,7 +160,7 @@ class RemoteAPI(ABC):
             expected_keys_input = all(self.id_key in item for item in original)
             expected_keys_responses = all(self.id_key in item for item in responses)
             if not all((expected_keys_input, expected_keys_responses)):
-                self.logger.warning(
+                self.logger.debug(
                     "Could not merge responses to given user input | "
                     f"Reason: unordered and cannot order on {self.id_key=} | "
                     f"{expected_keys_input=} {expected_keys_responses=}"
@@ -456,8 +456,8 @@ class RemoteAPI(ABC):
         raise NotImplementedError
 
     def __enter__(self):
-        self.authorise()
+        self.handler.__enter__()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
+        self.handler.__exit__(exc_type, exc_val, exc_tb)

--- a/musify/libraries/remote/core/processors/check.py
+++ b/musify/libraries/remote/core/processors/check.py
@@ -361,7 +361,7 @@ class RemoteItemChecker(ItemMatcher, InputProcessor):
 
         remaining = removed + missing
         count_start = len(remaining)
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(thread_name_prefix="checker") as executor:
             tasks: Iterator[tuple[MusifyItemSettable, MusifyItemSettable | None]] = executor.map(
                 lambda item: (
                     item, self.match(item, results=added, match_on=[Fields.TITLE], allow_karaoke=self.allow_karaoke)

--- a/musify/libraries/remote/core/processors/check.py
+++ b/musify/libraries/remote/core/processors/check.py
@@ -361,7 +361,7 @@ class RemoteItemChecker(ItemMatcher, InputProcessor):
 
         remaining = removed + missing
         count_start = len(remaining)
-        with ThreadPoolExecutor(thread_name_prefix="checker") as executor:
+        with ThreadPoolExecutor() as executor:
             tasks: Iterator[tuple[MusifyItemSettable, MusifyItemSettable | None]] = executor.map(
                 lambda item: (
                     item, self.match(item, results=added, match_on=[Fields.TITLE], allow_karaoke=self.allow_karaoke)
@@ -369,7 +369,7 @@ class RemoteItemChecker(ItemMatcher, InputProcessor):
                 remaining if added else ()
             )
 
-        for item, match in list(tasks):
+        for item, match in tasks:
             if not match:
                 continue
 

--- a/musify/processors/match.py
+++ b/musify/processors/match.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import re
 from collections.abc import Iterable, Callable, MutableSequence
-from concurrent.futures import ThreadPoolExecutor, Future
+from concurrent.futures import ThreadPoolExecutor, Future, Executor
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -344,7 +344,7 @@ class ItemMatcher(Processor):
             self,
             source: T,
             results: Iterable[T],
-            executor: ThreadPoolExecutor,
+            executor: Executor,
             match_on: set[TagField] = ALL_TAG_FIELDS,
             allow_karaoke: bool = False,
     ) -> list[tuple[T, dict[TagField, Future[float] | list[list[Future[float]]]]]]:
@@ -380,7 +380,7 @@ class ItemMatcher(Processor):
             self,
             source: T,
             result: T,
-            executor: ThreadPoolExecutor,
+            executor: Executor,
             match_on: set[TagField] = ALL_TAG_FIELDS,
             allow_karaoke: bool = False,
     ) -> dict[TagField, Future[float] | list[list[Future[float]]]]:

--- a/tests/libraries/core/collection.py
+++ b/tests/libraries/core/collection.py
@@ -14,7 +14,6 @@ from musify.libraries.core.collection import MusifyCollection
 from musify.libraries.core.object import Library, Playlist, Track
 from musify.libraries.remote.core.library import RemoteLibrary
 from musify.libraries.remote.core.object import RemoteCollectionLoader
-from musify.processors.filter import FilterDefinedList, FilterIncludeExclude
 from tests.core.printer import PrettyPrinterTester
 
 
@@ -307,41 +306,6 @@ class LibraryTester(MusifyCollectionTester, metaclass=ABCMeta):
     @pytest.fixture
     def collection(self, library: Library) -> MusifyCollection:
         return library
-
-    @staticmethod
-    def test_get_filtered_playlists_basic(library: Library):
-        include = FilterDefinedList([name for name in library.playlists][:1])
-        pl_include = library.get_filtered_playlists(playlist_filter=include)
-        assert len(pl_include) == len(include) < len(library.playlists)
-        assert all(pl.name in include for pl in pl_include.values())
-
-        exclude = FilterIncludeExclude(
-            include=FilterDefinedList(),
-            exclude=FilterDefinedList([name for name in library.playlists][:1])
-        )
-        pl_exclude = library.get_filtered_playlists(playlist_filter=exclude)
-        assert len(pl_exclude) == len(library.playlists) - len(exclude.exclude.values) < len(library.playlists)
-        assert all(pl.name not in exclude for pl in pl_exclude.values())
-
-    @staticmethod
-    def test_get_filtered_playlists_on_tags(library: Library):
-        # filters out tags
-        filter_names = [item.name for item in next(pl for pl in library.playlists.values() if len(pl) > 0)[:2]]
-        filter_tags = {"name": [name.upper() + "  " for name in filter_names]}
-        expected_counts = {}
-        for name, pl in library.playlists.items():
-            count_remaining = len([item for item in pl if item.name not in filter_names])
-            if count_remaining < len(pl):
-                expected_counts[name] = count_remaining
-
-        if len(expected_counts) == 0:
-            raise Exception("Can't check filter_tags logic, no items to filter out from playlists")
-
-        filtered_playlists = library.get_filtered_playlists(**filter_tags)
-        for name, pl in filtered_playlists.items():
-            if name not in expected_counts:
-                continue
-            assert len(pl) == expected_counts[name]
 
     @staticmethod
     def assert_merge_playlists(source: Library, test_values: Any):


### PR DESCRIPTION
Added
------

* The following classes and methods have been modified to implement concurrency to improve performance:
   * :py:meth:`.LocalLibrary.save_tracks`
   * :py:meth:`.LocalLibrary.save_playlists`
   * :py:meth:`.LocalLibrary.json` + optimisation for extracting JSON data from tracks
   * :py:class:`.ItemMatcher`
   * :py:class:`.RemoteItemChecker`
   * :py:class:`.RemoteItemSearcher`


Removed
-------

* ``get_filtered_playlists`` method from :py:class:`.Library`.
  This contained author specific logic and was not appropriate for general use