### PR TITLE
switch ItemMatcher inheritance to composite pattern on remote processors

### DIFF
--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -72,6 +72,8 @@ Changed
 * Renamed 'kind' property on :py:class:`.LocalTrack` to 'type' to avoid clashing property names
 * :py:class:`.ItemMatcher`, :py:class:`.RemoteItemChecker`, and :py:class:`.RemoteItemSearcher` now accept
   all MusifyItem types that may have their URI property set manually
+* :py:class:`.RemoteItemChecker` and :py:class:`.RemoteItemSearcher` no longer inherit from :py:class:`.ItemMatcher`.
+  Composite pattern used instead.
 * :py:class:`.ItemSorter` now shuffles randomly on unsupported types
   + prioritises fields settings over shuffle settings
 * :py:meth:`.Comparer._in_range` now uses inclusive range i.e. ``a <= x <= b`` where ``x`` is the value to compare
@@ -81,6 +83,7 @@ Changed
 * Moved loading of XML file logic from :py:class:`.XAutoPF` to :py:class:`.XMLPlaylistParser`.
   :py:class:`.XMLPlaylistParser` is now solely responsible for all XML parsing and handling
   for :py:class:`.XAutoPF` files
+* :
 
 Fixed
 -----

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -83,7 +83,6 @@ Changed
 * Moved loading of XML file logic from :py:class:`.XAutoPF` to :py:class:`.XMLPlaylistParser`.
   :py:class:`.XMLPlaylistParser` is now solely responsible for all XML parsing and handling
   for :py:class:`.XAutoPF` files
-* :
 
 Fixed
 -----

--- a/musify/processors/match.py
+++ b/musify/processors/match.py
@@ -84,34 +84,39 @@ class ItemMatcher(Processor):
         #: The :py:class:`MusifyLogger` for this  object
         self.logger: MusifyLogger = logging.getLogger(__name__)
 
-    def _log_padded(self, log: MutableSequence[str], pad: str = ' ') -> None:
-        """Wrapper for logging lists in a correctly aligned format"""
-        log[0] = pad * 3 + ' ' + (log[0] if log[0] else "unknown")
-        self.logger.debug(" | ".join(log))
+    def log_messages(self, messages: MutableSequence[str], pad: str = ' ') -> None:
+        """
+        Log lists of ``messages`` in a uniform aligned format with a given ``pad`` character.
+
+        Convenience function for ensuring consistent log format for results of operations of this class
+        and any other classes which use this class.
+        """
+        messages[0] = pad * 3 + ' ' + (messages[0] if messages[0] else "unknown")
+        self.logger.debug(" | ".join(messages))
 
     def _log_algorithm(self, source: MusifyObject, extra: Iterable[str] = ()) -> None:
-        """Wrapper for initially logging an algorithm in a correctly aligned format"""
+        """Wrapper for initially logging an algorithm in a uniform aligned format"""
         algorithm = inspect.stack()[1][0].f_code.co_name.upper().lstrip("_").replace("_", " ")
         log = [source.name, algorithm]
         if extra:
             log.extend(extra)
-        self._log_padded(log, pad='>')
+        self.log_messages(log, pad='>')
 
     def _log_test[T: MusifyObject](self, source: T, result: T, test: Any, extra: Iterable[str] = ()) -> None:
-        """Wrapper for initially logging a test result in a correctly aligned format"""
+        """Wrapper for initially logging a test result in a uniform aligned format"""
         algorithm = inspect.stack()[1][0].f_code.co_name.replace("match", "").upper().lstrip("_").replace("_", " ")
         log_result = f"> Testing URI: {result.uri}" if hasattr(result, "uri") else "> Test failed"
         log = [source.name, log_result, f"{algorithm:<10}={test:<5}"]
         if extra:
             log.extend(extra)
-        self._log_padded(log)
+        self.log_messages(log)
 
     def _log_match[T: MusifyObject](self, source: T, result: T, extra: Iterable[str] = ()) -> None:
         """Wrapper for initially logging a match in a correctly aligned format"""
         log = [source.name, f"< Matched URI: {result.uri}"]
         if extra:
             log.extend(extra)
-        self._log_padded(log, pad='<')
+        self.log_messages(log, pad='<')
 
     def clean_tags(self, source: MusifyObject) -> None:
         """


### PR DESCRIPTION
Changed
--------

* :py:class:`.RemoteItemChecker` and :py:class:`.RemoteItemSearcher` no longer inherit from :py:class:`.ItemMatcher`.
  Composite pattern used instead.