### PR TITLE
fix bug in ItemMatcher colation

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout 🛒
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: ⚙️ Setup - Python 🐍
         uses: actions/setup-python@v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: ⚙️ Setup - Python 🐍
         uses: actions/setup-python@v5

--- a/.idea/musify.iml
+++ b/.idea/musify.iml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/.ipynb_checkpoints" />
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+      <excludeFolder url="file://$MODULE_DIR$/.venv_lin" />
+      <excludeFolder url="file://$MODULE_DIR$/dist" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.12 (musify)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
   <component name="PyDocumentationSettings">
     <option name="format" value="PLAIN" />
     <option name="myDocStringFormat" value="Plain" />

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -31,6 +31,14 @@ Release History
 The format is based on `Keep a Changelog <https://keepachangelog.com/en>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_
 
+0.9.1
+=====
+
+Fixed
+-----
+
+* Bug in :py:meth:`.ItemMatcher.match` where operations always returned the last item in the given list of ``results``
+
 
 0.9.0
 =====

--- a/tests/processors/test_match.py
+++ b/tests/processors/test_match.py
@@ -184,7 +184,7 @@ class TestItemMatcher(PrettyPrinterTester):
         track3.artist = f"artist{sep}nope{sep}other"
         track3.year = 2015
         assert matcher.match(track1, [track2, track3], min_score=0.2, max_score=0.8) == track3
-        assert matcher(track1, [track2, track3], min_score=0.2, max_score=0.8) == track3
+        assert matcher(track1, [track3, track2], min_score=0.2, max_score=0.8) == track3
 
         # track4 score is above max_score causing an early stop
         track4 = random_track()
@@ -193,7 +193,7 @@ class TestItemMatcher(PrettyPrinterTester):
         track4.album = "album"
         track4._reader.file.info.length = 100
         track4.year = 2015
-        assert matcher.match(track1, [track2, track4, track3], min_score=0.2, max_score=0.8) == track4
+        assert matcher.match(track1, [track4, track2, track3], min_score=0.2, max_score=0.8) == track4
         assert matcher(track1, [track2, track4, track3], min_score=0.2, max_score=0.8) == track4
 
     def test_allows_karaoke(self, matcher: ItemMatcher, track1: LocalTrack, track2: LocalTrack):


### PR DESCRIPTION
Fixes bug in :py:meth:`.ItemMatcher.match` where operations always returned the last item in the given list of ``results``