### PR TITLE
Replace `requests-cache` with custom requests cache + fix slots

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: 🧪 Run tests
         run: |
-          pytest -n auto --junit-xml=test-results.xml
+          pytest -n auto -m "not manual" --junit-xml=test-results.xml
 
       - name: 📃 Publish test results report
         uses: pmeier/pytest-results-action@main

--- a/.gitignore
+++ b/.gitignore
@@ -133,7 +133,7 @@ cython_debug/
 
 # binary/cache files
 **.sql*
-**cache*
+**cache.*
 
 # large data & log folders
 _data/

--- a/.gitignore
+++ b/.gitignore
@@ -133,7 +133,6 @@ cython_debug/
 
 # binary/cache files
 **.sql*
-**cache.*
 
 # large data & log folders
 _data/

--- a/.idea/dictionaries/gmarino.xml
+++ b/.idea/dictionaries/gmarino.xml
@@ -1,0 +1,3 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="gmarino" />
+</component>

--- a/.idea/musify.iml
+++ b/.idea/musify.iml
@@ -8,7 +8,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.venv_lin" />
       <excludeFolder url="file://$MODULE_DIR$/dist" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.12 (musify)" jdkType="Python SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/docs/_howto/scripts/remote.new-music.py
+++ b/docs/_howto/scripts/remote.new-music.py
@@ -33,7 +33,7 @@ if albums_need_extend:
 
     bar = library.logger.get_progress_bar(iterable=albums_need_extend, desc="Getting album tracks", unit="albums")
     for album in bar:
-        api.extend_items(album.response, kind=kind, key=key, use_cache=False)
+        api.extend_items(album.response, kind=kind, key=key)
         album.refresh(skip_checks=False)
 
 # log stats about the loaded artists

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,12 @@ typehints_use_rtype = False
 templates_path = ["_templates"]
 exclude_patterns = ["_build"]
 
+suppress_warnings = [
+    # TODO: figure out how to suppress warnings for the following warnings:
+    #  - WARNING: No classes found for inheritance diagram
+    #  - WARNING: Cannot resolve forward reference in type annotations of ...: name 'T' is not defined
+]
+
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -32,7 +32,7 @@ Setup your development environment
       pip install -e '.[docs]'  # installs just the core package + the required dependencies for building documentation
 
 6. Optionally, to ensure inhreitance diagrams in the documentation render correctly, install graphviz.
-   More info on how to install graphviz for you platform can be found `here <https://graphviz.org/download/>`_
+   See `here <https://graphviz.org/download/>`_ for platform-specific info on how to install graphviz.
 
 Making changes and testing
 ==========================

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -31,6 +31,8 @@ Setup your development environment
       pip install -e '.[dev]'  # installs the `test` dependencies + dependencies for linting and other development uses
       pip install -e '.[docs]'  # installs just the core package + the required dependencies for building documentation
 
+6. Optionally, to ensure inhreitance diagrams in the documentation render correctly, install graphviz.
+   More info on how to install graphviz for you platform can be found `here <https://graphviz.org/download/>`_
 
 Making changes and testing
 ==========================

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -59,6 +59,7 @@ Fixed
 
 * Added missing variables to __slots__ definitions
 * Correctly applied __slots__ pattern to child classes. Now works as expected.
+* :py:class:`.LocalTrack` now copies tags as expected when calling ``copy.copy()``
 
 Removed
 -------

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -50,11 +50,15 @@ Changed
   Now takes :py:class:`.APIAuthoriser` and :py:class:`.ResponseCache` objects for instantiation
   instead of kwargs for :py:class:`.APIAuthoriser`.
 * :py:class:`.APIAuthoriser` kwargs given to :py:class:`.SpotifyAPI` now merge with default kwargs.
+* Moved ``remote_wrangler`` attribute from :py:class:`.MusifyCollection` to :py:class:`.LocalCollection`.
+  This attribute was only needed by :py:class:`.LocalCollection` branch of child classes.
+* Moved ``logger`` attribute from :py:class:`.Library` to :py:class:`.RemoteLibrary`.
 
 Fixed
 -----
 
 * Added missing variables to __slots__ definitions
+* Correctly applied __slots__ pattern to child classes. Now works as expected.
 
 Removed
 -------

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -31,6 +31,37 @@ Release History
 The format is based on `Keep a Changelog <https://keepachangelog.com/en>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_
 
+1.0.0
+=====
+
+Added
+-----
+
+* Custom API caching backend to replace dependency on `requests-cache` package.
+  Currently only supports SQLite backend. More backends can be implemented in future if desired.
+* Cache settings for specific `GET` request endpoints on :py:class:`.SpotifyAPI` replacing need
+  for per method ``use_cache`` parameter.
+
+Changed
+-------
+
+* Replaced ``authorise`` method from :py:class:`.APIAuthoriser` with __call__ method for class.
+* Dependency injection pattern for :py:class:`.RequestHandler` and :py:class:`.RemoteAPI`.
+  Now takes :py:class:`.APIAuthoriser` and :py:class:`.ResponseCache` objects for instantiation
+  instead of kwargs for :py:class:`.APIAuthoriser`.
+* :py:class:`.APIAuthoriser` kwargs given to :py:class:`.SpotifyAPI` now merge with default kwargs.
+
+Fixed
+-----
+
+* Added missing variables to __slots__ definitions
+
+Removed
+-------
+
+* ``use_cache`` parameter from all :py:class:`.RemoteAPI` related methods.
+  Cache settings now handled by :py:class:`.ResponseCache`
+
 0.9.2
 =====
 

--- a/musify/api/authorise.py
+++ b/musify/api/authorise.py
@@ -352,7 +352,7 @@ class APIAuthoriser:
         response = requests.get(headers=self.headers, **self.test_args)
         try:
             response = response.json()
-        except json.JSONDecodeError:
+        except json.decoder.JSONDecodeError:
             response = response.text
 
         result = self.test_condition(response)

--- a/musify/api/authorise.py
+++ b/musify/api/authorise.py
@@ -188,7 +188,7 @@ class APIAuthoriser:
         with open(self.token_file_path, "w") as file:
             json.dump(self.token, file, indent=2)
 
-    def authorise(self, force_load: bool = False, force_new: bool = False) -> dict[str, str]:
+    def __call__(self, force_load: bool = False, force_new: bool = False) -> dict[str, str]:
         """
         Main method for authorisation which tests/refreshes/reauthorises as needed.
 

--- a/musify/api/cache/backend/__init__.py
+++ b/musify/api/cache/backend/__init__.py
@@ -1,0 +1,5 @@
+from musify.api.cache.backend.base import ResponseCache
+from musify.api.cache.backend.sqlite import SQLiteCache
+
+CACHE_CLASSES: frozenset[type[ResponseCache]] = frozenset({SQLiteCache})
+CACHE_TYPES = frozenset(cls.type for cls in CACHE_CLASSES)

--- a/musify/api/cache/backend/base.py
+++ b/musify/api/cache/backend/base.py
@@ -161,6 +161,20 @@ class ResponseCache[CT: Connection, ST: ResponseRepository](MutableMapping[str, 
 
     __slots__ = ("cache_name", "connection", "repository_getter", "expire", "_repositories")
 
+    # noinspection PyPropertyDefinition
+    @classmethod
+    @property
+    @abstractmethod
+    def type(cls) -> str:
+        """A string representing the type of the backend this class represents."""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def connect(cls, value: Any, **kwargs) -> Self:
+        """Connect to the backend from a given generic ``value``."""
+        raise NotImplementedError
+
     def __init__(
             self,
             cache_name: str,

--- a/musify/api/cache/backend/base.py
+++ b/musify/api/cache/backend/base.py
@@ -1,0 +1,225 @@
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import MutableMapping, Callable, Collection, Hashable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Protocol, Self
+
+from requests import Request, PreparedRequest, Response
+
+from musify.api.exception import CacheError
+from musify.log.logger import MusifyLogger
+
+
+DEFAULT_EXPIRE: timedelta = timedelta(weeks=1)
+
+
+class Connection(Protocol):
+
+    def close(self) -> None:
+        """Close the connection to the storage layer."""
+
+
+@dataclass
+class RequestSettings(ABC):
+    """Settings for a request type for a given endpoint to be used to configure storage in the cache backend."""
+    name: str
+
+    @abstractmethod
+    def get_id(self, url: str) -> str:
+        """Extracts the ID for a request from the given ``url``."""
+        raise NotImplementedError
+
+
+class PaginatedRequestSettings(RequestSettings, ABC):
+    @abstractmethod
+    def get_offset(self, url: str) -> int:
+        """Extracts the offset for a paginated request from the given ``url``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_limit(self, url: str) -> int:
+        """Extracts the limit for a paginated request from the given ``url``."""
+        raise NotImplementedError
+
+
+class ResponseRepository[T: Connection, KT, VT](MutableMapping[KT, VT], Hashable, ABC):
+
+    __slots__ = ("logger", "connection", "settings", "_expire")
+
+    @property
+    def expire(self) -> datetime:
+        """The datetime representing the maximum allowed expiry time from now."""
+        return datetime.now() - self._expire
+
+    def __init__(self, connection: T, settings: RequestSettings, expire: timedelta = DEFAULT_EXPIRE):
+        # noinspection PyTypeChecker
+        #: The :py:class:`MusifyLogger` for this  object
+        self.logger: MusifyLogger = logging.getLogger(__name__)
+
+        self.connection = connection
+        self.settings = settings
+        self._expire = expire
+
+    def __hash__(self):
+        return hash(self.settings.name)
+
+    def close(self) -> None:
+        """Close the connection to the storage layer."""
+        self.commit()
+        self.connection.close()
+
+    @abstractmethod
+    def commit(self) -> None:
+        """Commit the changes to the data"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def count(self, expired: bool = True) -> int:
+        """
+        Get the number of responses in this storage.
+
+        :param expired: Whether to include expired responses in the final count.
+        :return: The number of responses in this storage.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def serialise(self, value: Any) -> VT:
+        """Serialize a given ``value`` to a type that can be persisted to the storage layer."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def deserialise(self, value: VT) -> Any:
+        """Deserialize a value from the storage layer to the expected response value type."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_key_from_request(self, request: Request | PreparedRequest) -> KT:
+        """Extract the keys to use when persisting responses for a given ``request``"""
+        raise NotImplementedError
+
+    def get_response(self, request: KT | Request | PreparedRequest | Response) -> VT | None:
+        """Get the response relating to the given ``request`` from this storage if it exists."""
+        if isinstance(request, Response):
+            request = request.request
+
+        keys = self.get_key_from_request(request) if isinstance(request, Request | PreparedRequest) else request
+        return self.get(keys, None)
+
+    def get_responses(self, requests: Collection[KT | Request | PreparedRequest | Response]) -> list[VT]:
+        """
+        Get the responses relating to the given ``requests`` from this storage if they exist.
+        Returns results unordered.
+        """
+        results = [self.get_response(request) for request in requests]
+        return [result for result in results if result is not None]
+
+    def save_response(self, response: Response) -> None:
+        """Save the given ``response`` to this storage."""
+        keys = self.get_key_from_request(response.request)
+        self[keys] = response.text
+
+    def save_responses(self, responses: Collection[Response]) -> None:
+        """Save the given ``responses`` to this storage."""
+        for response in responses:
+            self.save_response(response)
+
+    def delete_response(self, request: KT | Request | PreparedRequest | Response) -> None:
+        """Delete the given ``request`` from this storage if it exists."""
+        if isinstance(request, Response):
+            request = request.request
+        keys = self.get_key_from_request(request) if isinstance(request, Request | PreparedRequest) else request
+        self.pop(keys, None)
+
+    def delete_responses(self, requests: Collection[KT | Request | PreparedRequest | Response]) -> None:
+        """Delete the given ``requests`` from this storage if they exist."""
+        for request in requests:
+            self.delete_response(request)
+
+
+class ResponseCache[CT: Connection, ST: ResponseRepository](ABC):
+
+    __slots__ = ("cache_name", "connection", "storage_getter", "expire", "storage")
+
+    def __init__(
+            self,
+            cache_name: str,
+            connection: CT,
+            storage_getter: Callable[[Self, str], ST] = None,
+            expire: timedelta = DEFAULT_EXPIRE,
+    ):
+        self.cache_name = cache_name
+        self.connection = connection
+        self.storage_getter = storage_getter
+        self.expire = expire
+
+        self.storage: dict[str, ST] = {}
+
+    def close(self):
+        """Close the connection to the storage layer."""
+        self.connection.close()
+
+    @abstractmethod
+    def create_storage(self, settings: RequestSettings) -> ResponseRepository:
+        """
+        Create and return a :py:class:`SQLiteResponseStorage` and store this object in this cache.
+
+        Creates a storage with the given ``settings`` in the cache if it doesn't exist.
+        """
+        raise NotImplementedError
+
+    def get_storage_for_url(self, url: str) -> ST | None:
+        """Returns the storage to use from the stored storages in this cache for the given URL."""
+        if self.storage_getter is not None:
+            return self.storage_getter(self, url)
+
+    def _get_storage_for_requests(self, requests: Collection[Request | PreparedRequest | Response]) -> ST | None:
+        storage = {
+            self.get_storage_for_url(request.request.url if isinstance(request, Response) else request.url)
+            for request in requests
+        }
+        if len(storage) > 1:
+            raise CacheError(
+                "Too many different types of requests given. Given requests must relate to the same storage type"
+            )
+        return next(iter(storage))
+
+    def get_response(self, request: Request | PreparedRequest | Response) -> Any:
+        """Get the response relating to the given ``request`` from the appropriate storage if it exists."""
+        storage = self._get_storage_for_requests([request])
+        if storage is not None:
+            return storage.get_response(request)
+
+    def get_responses(self, requests: Collection[Request | PreparedRequest | Response]) -> list:
+        """
+        Get the responses relating to the given ``requests`` from the appropriate storage if they exist.
+        Returns results unordered.
+        """
+        storage = self._get_storage_for_requests(requests)
+        if storage is not None:
+            return storage.get_responses(requests)
+
+    def save_response(self, response: Response) -> None:
+        """Save the given ``response`` to the appropriate storage."""
+        storage = self._get_storage_for_requests([response])
+        if storage is not None:
+            return storage.save_response(response)
+
+    def save_responses(self, responses: Collection[Response]) -> None:
+        """Save the given ``responses`` to the appropriate storage."""
+        storage = self._get_storage_for_requests(responses)
+        if storage is not None:
+            return storage.save_responses(responses)
+
+    def delete_response(self, request: Request | PreparedRequest | Response) -> None:
+        """Delete the given ``request`` from the appropriate storage if it exists."""
+        storage = self._get_storage_for_requests([request])
+        if storage is not None:
+            return storage.delete_response(request)
+
+    def delete_responses(self, requests: Collection[Request | PreparedRequest | Response]) -> None:
+        """Delete the given ``requests`` from the appropriate storage."""
+        storage = self._get_storage_for_requests(requests)
+        if storage is not None:
+            return storage.delete_responses(requests)

--- a/musify/api/cache/backend/sqlite.py
+++ b/musify/api/cache/backend/sqlite.py
@@ -1,0 +1,179 @@
+import json
+import os
+import sqlite3
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+from os.path import splitext, dirname, join
+from tempfile import gettempdir
+from typing import Any, Self
+
+from requests import Request, PreparedRequest
+
+from musify import PROGRAM_NAME
+from musify.api.cache.backend.base import ResponseCache, ResponseRepository, RequestSettings, PaginatedRequestSettings
+from musify.api.cache.backend.base import DEFAULT_EXPIRE
+
+
+class SQLiteTable[KT: tuple[Any, ...], VT: str](ResponseRepository[sqlite3.Connection, KT, VT]):
+    """
+
+    :param expire: The expiry time to apply to cached responses after which responses are invalidated.
+    """
+
+    __slots__ = ()
+
+    data_key = "data"
+    expiry_key = "expires_at"
+
+    @property
+    def _primary_key_columns(self) -> Mapping[str, str]:
+        """A map of column names to column data types for the primary keys of this storage."""
+        keys = {"method": "VARCHAR(10)", "id": "TEXT"}
+        if isinstance(self.settings, PaginatedRequestSettings):
+            keys["offset"] = "INT4"
+            keys["limit"] = "INT4"
+
+        return keys
+
+    def get_key_from_request(self, request: Request | PreparedRequest) -> KT:
+        keys = [str(request.method), self.settings.get_id(request.url)]
+        if isinstance(self.settings, PaginatedRequestSettings):
+            keys.append(self.settings.get_offset(request.url))
+            keys.append(self.settings.get_limit(request.url))
+
+        return tuple(keys)
+
+    def __init__(
+            self, connection: sqlite3.Connection, settings: RequestSettings, expire: timedelta = DEFAULT_EXPIRE
+    ):
+        super().__init__(connection=connection, settings=settings, expire=expire)
+
+        self.create_table()
+
+    def create_table(self):
+        """Create the table for this storage kind in the backend database if it doesn't already exist."""
+        ddl_sep = "\t, "
+
+        ddl = "\n".join((
+            f"CREATE TABLE IF NOT EXISTS {self.settings.name} (",
+            "\t" + f"\n{ddl_sep}".join(
+                f"{key} {data_type} NOT NULL" for key, data_type in self._primary_key_columns.items()
+            ),
+            f"{ddl_sep}{self.expiry_key} TIMESTAMP",
+            f"{ddl_sep}{self.data_key} TEXT",
+            f"{ddl_sep}PRIMARY KEY ({", ".join(self._primary_key_columns)})"
+            ");\n"
+            f"CREATE INDEX IF NOT EXISTS idx_{self.expiry_key} ON {self.settings.name}({self.expiry_key});"
+        ))
+
+        self.logger.debug(f"Creating {self.settings.name!r} table with the following DDL:\n{ddl}")
+        self.connection.executescript(ddl)
+
+    def commit(self) -> None:
+        self.connection.commit()
+
+    def count(self, expired: bool = True) -> int:
+        query = f"SELECT COUNT(*) FROM {self.settings.name}"
+        if not expired:
+            query += f"\nWHERE {self.expiry_key} IS NULL OR {self.expiry_key} > {datetime.now()}"
+
+        return self.connection.execute(query).fetchone()[0]
+
+    def __iter__(self):
+        query = f"SELECT {", ".join(self._primary_key_columns)}, {self.data_key} FROM {self.settings.name}"
+        for row in self.connection.execute(query):
+            yield row[:-1]
+
+    def __len__(self):
+        return self.count()
+
+    def __getitem__(self, __key):
+        query = "\n".join((
+            f"SELECT {self.data_key} FROM {self.settings.name}",
+            f"WHERE {self.expiry_key} < ?",
+            f"\tAND {"\n\tAND ".join(f"{key} = ?" for key in self._primary_key_columns)}",
+        ))
+
+        cur = self.connection.execute(query, (datetime.now(), *__key))
+        row = cur.fetchone()
+        cur.close()
+        if not row:
+            raise KeyError(__key)
+
+        return self.deserialise(row[0])
+
+    def __setitem__(self, __key, __value):
+        query = "\n".join((
+            f"INSERT OR REPLACE INTO {self.settings.name} (",
+            f"\t{", ".join(self._primary_key_columns)}, {self.expiry_key}, {self.data_key}"
+            ") ",
+            f"VALUES ({",".join("?" * len(self._primary_key_columns))},?,?);",
+        ))
+
+        data = self.serialise(__value)
+        self.connection.execute(query, (*__key, self.expire, data))
+
+    def __delitem__(self, __key):
+        query = "\n".join((
+            f"DELETE FROM {self.settings.name}",
+            f"WHERE {"\n\tAND ".join(f"{key} = ?" for key in self._primary_key_columns)}",
+        ))
+
+        cur = self.connection.execute(query, __key)
+        if not cur.rowcount:
+            raise KeyError(__key)
+
+    def serialise(self, value: Any) -> VT:
+        if isinstance(value, str):
+            return value
+        return json.dumps(value)
+
+    def deserialise(self, value: VT) -> dict[str, Any]:
+        if isinstance(value, dict):
+            return value
+        return json.loads(value)
+
+
+class SQLiteCache(ResponseCache[sqlite3.Connection, SQLiteTable]):
+
+    __slots__ = ()
+
+    @staticmethod
+    def _get_sqlite_path(path: str) -> str:
+        if not splitext(path)[1] == ".sqlite":  # add/replace extension if not given
+            path += ".sqlite"
+        return path
+
+    @staticmethod
+    def _clean_kwargs[T: dict](kwargs: T) -> T:
+        kwargs.pop("cache_name", None)
+        kwargs.pop("connection", None)
+        return kwargs
+
+    @classmethod
+    def connect_with_path(cls, path: str, **kwargs) -> Self:
+        """Connect with an SQLite DB at the given ``path`` and return an instantiated :py:class:`SQLiteResponseCache`"""
+        path = cls._get_sqlite_path(path)
+        os.makedirs(dirname(path), exist_ok=True)
+
+        connection = sqlite3.Connection(database=path)
+        return cls(cache_name=path, connection=connection, **cls._clean_kwargs(kwargs))
+
+    @classmethod
+    def connect_with_in_memory_db(cls, **kwargs) -> Self:
+        """Connect with an in-memory SQLite DB and return an instantiated :py:class:`SQLiteResponseCache`"""
+        connection = sqlite3.Connection(database="file::memory:?cache=shared")
+        return cls(cache_name="__IN_MEMORY__", connection=connection, **cls._clean_kwargs(kwargs))
+
+    @classmethod
+    def connect_with_temp_db(cls, name: str = f"{PROGRAM_NAME.lower()}_db.tmp", **kwargs) -> Self:
+        """Connect with a temporary SQLite DB and return an instantiated :py:class:`SQLiteResponseCache`"""
+        path = cls._get_sqlite_path(join(gettempdir(), name))
+
+        connection = sqlite3.Connection(database=path)
+        return cls(cache_name=path, connection=connection, **cls._clean_kwargs(kwargs))
+
+    def create_storage(self, settings: RequestSettings) -> SQLiteTable:
+        storage = SQLiteTable(connection=self.connection, settings=settings, expire=self.expire)
+        self.storage[settings.name] = storage
+        return storage

--- a/musify/api/cache/backend/sqlite.py
+++ b/musify/api/cache/backend/sqlite.py
@@ -94,7 +94,7 @@ class SQLiteTable[KT: tuple[Any, ...], VT: str](ResponseRepository[sqlite3.Conne
             f"\tAND {"\n\tAND ".join(f"{key} = ?" for key in self._primary_key_columns)}",
         ))
 
-        cur = self.connection.execute(query, (datetime.now(), *__key))
+        cur = self.connection.execute(query, (datetime.now().isoformat(), *__key))
         row = cur.fetchone()
         cur.close()
         if not row:
@@ -111,7 +111,7 @@ class SQLiteTable[KT: tuple[Any, ...], VT: str](ResponseRepository[sqlite3.Conne
         ))
 
         data = self.serialise(__value)
-        self.connection.execute(query, (*__key, self.expire, data))
+        self.connection.execute(query, (*__key, self.expire.isoformat(), data))
 
     def __delitem__(self, __key):
         query = "\n".join((

--- a/musify/api/cache/backend/sqlite.py
+++ b/musify/api/cache/backend/sqlite.py
@@ -34,10 +34,10 @@ class SQLiteTable[KT: tuple[Any, ...], VT: str](ResponseRepository[sqlite3.Conne
     @property
     def _primary_key_columns(self) -> Mapping[str, str]:
         """A map of column names to column data types for the primary keys of this repository."""
-        keys = {"method": "VARCHAR(10)", "id": "TEXT"}
+        keys = {"method": "VARCHAR(10)", "id": "VARCHAR(50)"}
         if isinstance(self.settings, PaginatedRequestSettings):
-            keys["offset"] = "INT4"
-            keys["page_count"] = "INT2"
+            keys["offset"] = "INT2"
+            keys["size"] = "INT2"
 
         return keys
 

--- a/musify/api/cache/backend/sqlite.py
+++ b/musify/api/cache/backend/sqlite.py
@@ -4,6 +4,7 @@ import sqlite3
 from collections.abc import Mapping
 from datetime import datetime, timedelta
 from os.path import splitext, dirname, join
+from pathlib import Path
 from tempfile import gettempdir
 from typing import Any, Self
 
@@ -181,9 +182,9 @@ class SQLiteCache(ResponseCache[sqlite3.Connection, SQLiteTable]):
         return cls.connect_with_path(path=value, **kwargs)
 
     @classmethod
-    def connect_with_path(cls, path: str, **kwargs) -> Self:
+    def connect_with_path(cls, path: str | Path, **kwargs) -> Self:
         """Connect with an SQLite DB at the given ``path`` and return an instantiated :py:class:`SQLiteResponseCache`"""
-        path = cls._get_sqlite_path(path)
+        path = cls._get_sqlite_path(str(path))
         if dirname(path):
             os.makedirs(dirname(path), exist_ok=True)
 

--- a/musify/api/cache/backend/sqlite.py
+++ b/musify/api/cache/backend/sqlite.py
@@ -187,7 +187,7 @@ class SQLiteCache(ResponseCache[sqlite3.Connection, SQLiteTable]):
     @classmethod
     def connect_with_in_memory_db(cls, **kwargs) -> Self:
         """Connect with an in-memory SQLite DB and return an instantiated :py:class:`SQLiteResponseCache`"""
-        connection = sqlite3.Connection(database="file::memory:?cache=shared")
+        connection = sqlite3.Connection(database="file::memory:?cache=shared", uri=True)
         return cls(cache_name="__IN_MEMORY__", connection=connection, **cls._clean_kwargs(kwargs))
 
     @classmethod

--- a/musify/api/cache/backend/sqlite.py
+++ b/musify/api/cache/backend/sqlite.py
@@ -152,6 +152,12 @@ class SQLiteCache(ResponseCache[sqlite3.Connection, SQLiteTable]):
 
     __slots__ = ()
 
+    # noinspection PyPropertyDefinition
+    @classmethod
+    @property
+    def type(cls):
+        return "sqlite"
+
     @staticmethod
     def _get_sqlite_path(path: str) -> str:
         if not splitext(path)[1] == ".sqlite":  # add/replace extension if not given
@@ -165,10 +171,15 @@ class SQLiteCache(ResponseCache[sqlite3.Connection, SQLiteTable]):
         return kwargs
 
     @classmethod
+    def connect(cls, value: Any, **kwargs) -> Self:
+        return cls.connect_with_path(path=value, **kwargs)
+
+    @classmethod
     def connect_with_path(cls, path: str, **kwargs) -> Self:
         """Connect with an SQLite DB at the given ``path`` and return an instantiated :py:class:`SQLiteResponseCache`"""
         path = cls._get_sqlite_path(path)
-        os.makedirs(dirname(path), exist_ok=True)
+        if dirname(path):
+            os.makedirs(dirname(path), exist_ok=True)
 
         connection = sqlite3.Connection(database=path)
         return cls(cache_name=path, connection=connection, **cls._clean_kwargs(kwargs))

--- a/musify/api/cache/backend/sqlite.py
+++ b/musify/api/cache/backend/sqlite.py
@@ -99,7 +99,7 @@ class SQLiteTable[KT: tuple[Any, ...], VT: str](ResponseRepository[sqlite3.Conne
             yield row[:-1]
 
     def __len__(self):
-        return self.count()
+        return self.count(expired=False)
 
     def __getitem__(self, __key):
         query = "\n".join((

--- a/musify/api/cache/backend/sqlite.py
+++ b/musify/api/cache/backend/sqlite.py
@@ -179,7 +179,9 @@ class SQLiteCache(ResponseCache[sqlite3.Connection, SQLiteTable]):
 
     @classmethod
     def connect(cls, value: Any, **kwargs) -> Self:
-        return cls.connect_with_path(path=value, **kwargs)
+        cache = cls.connect_with_path(path=value, **kwargs)
+        cache.connection.autocommit = True
+        return cache
 
     @classmethod
     def connect_with_path(cls, path: str | Path, **kwargs) -> Self:

--- a/musify/api/cache/session.py
+++ b/musify/api/cache/session.py
@@ -1,9 +1,14 @@
-from requests import Session, Request, Response
+from requests import Session, Request, Response, PreparedRequest
 
-from musify.api.cache.backend.base import ResponseCache
+from musify.api.cache.backend.base import ResponseCache, ResponseRepository
 
 
 class CachedSession(Session):
+    """
+    A modified session which attempts to get/save responses from/to a stored cache before/after sending it.
+
+    :param cache: The cache to use for managing cached responses.
+    """
 
     __slots__ = ("cache",)
 
@@ -32,6 +37,52 @@ class CachedSession(Session):
             cert=None,
             json=None,
     ):
+
+        """
+        Constructs a :class:`Request <Request>` and prepares it.
+        First attempts to find the response for the request in the cache and, if not found, sends it.
+        If sent and matching cache repository was found, persist the response to the repository.
+        Returns :class:`Response <Response>` object.
+
+        :param method: method for the new :class:`Request` object.
+        :param url: URL for the new :class:`Request` object.
+        :param params: (optional) Dictionary or bytes to be sent in the query
+            string for the :class:`Request`.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the :class:`Request`.
+        :param json: (optional) json to send in the body of the
+            :class:`Request`.
+        :param headers: (optional) Dictionary of HTTP Headers to send with the
+            :class:`Request`.
+        :param cookies: (optional) Dict or CookieJar object to send with the
+            :class:`Request`.
+        :param files: (optional) Dictionary of ``'filename': file-like-objects``
+            for multipart encoding upload.
+        :param auth: (optional) Auth tuple or callable to enable
+            Basic/Digest/Custom HTTP Auth.
+        :param timeout: (optional) How long to wait for the server to send
+            data before giving up, as a float, or a :ref:`(connect timeout,
+            read timeout) <timeouts>` tuple.
+        :type timeout: float or tuple
+        :param allow_redirects: (optional) Set to True by default.
+        :type allow_redirects: bool
+        :param proxies: (optional) Dictionary mapping protocol or protocol and
+            hostname to the URL of the proxy.
+        :param hooks: Unknown.
+        :param stream: (optional) whether to immediately download the response
+            content. Defaults to ``False``.
+        :param verify: (optional) Either a boolean, in which case it controls whether we verify
+            the server's TLS certificate, or a string, in which case it must be a path
+            to a CA bundle to use. Defaults to ``True``. When set to
+            ``False``, requests will accept any TLS certificate presented by
+            the server, and will ignore hostname mismatches and/or expired
+            certificates, which will make your application vulnerable to
+            man-in-the-middle (MitM) attacks. Setting verify to ``False``
+            may be useful during local development or testing.
+        :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair.
+        :rtype: requests.Response
+        """
         req = Request(
             method=method.upper(),
             url=url,
@@ -45,37 +96,53 @@ class CachedSession(Session):
             hooks=hooks,
         )
         prep = self.prepare_request(req)
-        cached_data = self.cache.get_response(prep)
+
+        repository = self.cache.get_repository_from_requests(prep)
+        response = self._get_cached_response(prep, repository=repository)
+
+        if not response:
+            response = super().request(
+                method,
+                url,
+                params=params,
+                data=data,
+                headers=headers,
+                cookies=cookies,
+                files=files,
+                auth=auth,
+                timeout=timeout,
+                allow_redirects=allow_redirects,
+                proxies=proxies,
+                hooks=hooks,
+                stream=stream,
+                verify=verify,
+                cert=cert,
+                json=json,
+            )
+
+            if repository:
+                repository.save_response(response)
+
+        return response
+
+    def _get_cached_response(self, request: PreparedRequest, repository: ResponseRepository) -> Response | None:
+        if not repository:
+            return
+
+        cached_data = repository.get_response(request)
+        if not cached_data:
+            return
 
         if cached_data:  # emulate a response object and return it
             if not isinstance(cached_data, str):
-                repository = self.cache.get_repository_from_url(url)
-                cached_data = repository.serialise(cached_data)
+                repository = self.cache.get_repository_from_url(request.url)
+                cached_data = repository.serialize(cached_data)
 
             response = Response()
             response.encoding = "utf-8"
             response._content = cached_data.encode(response.encoding)
             response.status_code = 200
-            response.url = url
-            response.request = prep
+            response.url = request.url
+            response.request = request
 
             return response
-
-        return super().request(
-            method,
-            url,
-            params=params,
-            data=data,
-            headers=headers,
-            cookies=cookies,
-            files=files,
-            auth=auth,
-            timeout=timeout,
-            allow_redirects=allow_redirects,
-            proxies=proxies,
-            hooks=hooks,
-            stream=stream,
-            verify=verify,
-            cert=cert,
-            json=json,
-        )

--- a/musify/api/cache/session.py
+++ b/musify/api/cache/session.py
@@ -49,7 +49,7 @@ class CachedSession(Session):
 
         if cached_data:  # emulate a response object and return it
             if not isinstance(cached_data, str):
-                repository = self.cache.get_repository_for_url(url)
+                repository = self.cache.get_repository_from_url(url)
                 cached_data = repository.serialise(cached_data)
 
             response = Response()

--- a/musify/api/cache/session.py
+++ b/musify/api/cache/session.py
@@ -62,8 +62,8 @@ class CachedSession(Session):
         :param auth: (optional) Auth tuple or callable to enable
             Basic/Digest/Custom HTTP Auth.
         :param timeout: (optional) How long to wait for the server to send
-            data before giving up, as a float, or a :ref:`(connect timeout,
-            read timeout) <timeouts>` tuple.
+            data before giving up, as a float, or a `(connect timeout,
+            read timeout)` tuple.
         :type timeout: float or tuple
         :param allow_redirects: (optional) Set to True by default.
         :type allow_redirects: bool

--- a/musify/api/cache/session.py
+++ b/musify/api/cache/session.py
@@ -41,7 +41,8 @@ class CachedSession(Session):
         """
         Constructs a :class:`Request <Request>` and prepares it.
         First attempts to find the response for the request in the cache and, if not found, sends it.
-        If sent and matching cache repository was found, persist the response to the repository.
+        If ``persist`` is True request was sent and matching cache repository was found and ,
+        persist the response to the repository.
         Returns :class:`Response <Response>` object.
 
         :param method: method for the new :class:`Request` object.

--- a/musify/api/cache/session.py
+++ b/musify/api/cache/session.py
@@ -1,0 +1,81 @@
+from requests import Session, Request, Response
+
+from musify.api.cache.backend.base import ResponseCache
+
+
+class CachedSession(Session):
+
+    __slots__ = ("cache",)
+
+    def __init__(self, cache: ResponseCache):
+        super().__init__()
+
+        #: The cache to use when attempting to return a cached response.
+        self.cache = cache
+
+    def request(
+            self,
+            method,
+            url,
+            params=None,
+            data=None,
+            headers=None,
+            cookies=None,
+            files=None,
+            auth=None,
+            timeout=None,
+            allow_redirects=True,
+            proxies=None,
+            hooks=None,
+            stream=None,
+            verify=None,
+            cert=None,
+            json=None,
+    ):
+        req = Request(
+            method=method.upper(),
+            url=url,
+            headers=headers,
+            files=files,
+            data=data or {},
+            json=json,
+            params=params or {},
+            auth=auth,
+            cookies=cookies,
+            hooks=hooks,
+        )
+        prep = self.prepare_request(req)
+        cached_data = self.cache.get_response(prep)
+
+        if cached_data:  # emulate a response object and return it
+            if not isinstance(cached_data, str):
+                storage = self.cache.get_storage_for_url(url)
+                cached_data = storage.serialise(cached_data)
+
+            response = Response()
+            response.encoding = "utf-8"
+            response._content = cached_data.encode(response.encoding)
+            response.status_code = 200
+            response.url = url
+            response.request = prep
+
+            return response
+
+        return super().request(
+            method,
+            url,
+            params=params,
+            data=data,
+            headers=headers,
+            cookies=cookies,
+            files=files,
+            auth=auth,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            proxies=proxies,
+            hooks=hooks,
+            stream=stream,
+            verify=verify,
+            cert=cert,
+            json=json,
+        )

--- a/musify/api/cache/session.py
+++ b/musify/api/cache/session.py
@@ -49,8 +49,8 @@ class CachedSession(Session):
 
         if cached_data:  # emulate a response object and return it
             if not isinstance(cached_data, str):
-                storage = self.cache.get_storage_for_url(url)
-                cached_data = storage.serialise(cached_data)
+                repository = self.cache.get_repository_for_url(url)
+                cached_data = repository.serialise(cached_data)
 
             response = Response()
             response.encoding = "utf-8"

--- a/musify/api/exception.py
+++ b/musify/api/exception.py
@@ -22,4 +22,8 @@ class APIError(MusifyError):
 
 
 class RequestError(APIError):
-    """Exception raised for errors raised when making requests to an API."""
+    """Exception raised for errors relating to requests to an API."""
+
+
+class CacheError(APIError):
+    """Exception raised for errors relating to the cache as part of API operations."""

--- a/musify/api/request.py
+++ b/musify/api/request.py
@@ -70,6 +70,15 @@ class RequestHandler:
         self.backoff_count = 10
 
     def authorise(self, force_load: bool = False, force_new: bool = False) -> dict[str, str]:
+        """
+        Method for API authorisation which tests/refreshes/reauthorises as needed.
+
+        :param force_load: Reloads the token even if it's already been loaded into the object.
+            Ignored when force_new is True.
+        :param force_new: Ignore saved/loaded token and generate new token.
+        :return: Headers for request authorisation.
+        :raise APIError: If the token cannot be validated.
+        """
         headers = self.authoriser(force_load=force_load, force_new=force_new)
         self.session.headers.update(headers)
         return headers

--- a/musify/api/request.py
+++ b/musify/api/request.py
@@ -1,7 +1,6 @@
 """
 All operations relating to handling of requests to an API.
 """
-import inspect
 import json
 import logging
 from collections.abc import Mapping, Iterable

--- a/musify/api/request.py
+++ b/musify/api/request.py
@@ -2,6 +2,7 @@
 All operations relating to handling of requests to an API.
 """
 import json
+import logging
 from collections.abc import Mapping, Iterable
 from datetime import datetime, timedelta
 from http import HTTPStatus
@@ -10,32 +11,27 @@ from typing import Any
 
 import requests
 from requests import Response, Session
-from requests_cache import CachedSession, ExpirationTime
 
 from musify.api.authorise import APIAuthoriser
+from musify.api.cache.backend.base import ResponseCache
+from musify.api.cache.session import CachedSession
 from musify.api.exception import APIError
+from musify.log.logger import MusifyLogger
 
 
-class RequestHandler(APIAuthoriser):
+class RequestHandler:
     """
     Generic API request handler using cached responses for GET requests only.
     Caches GET responses for a maximum of 4 weeks by default.
     Handles error responses and backoff on failed requests.
     See :py:class:`APIAuthoriser` for more info on which params to pass to authorise requests.
 
-    :param cache_path: Path to use to store the requests session's sqlite cache.
-    :param cache_expiry: The expiry time to apply to cached responses after which responses are invalidated.
-    :param auth_kwargs: The authorisation kwargs to be passed to :py:class:`APIAuthoriser`.
+    :param authoriser: The authoriser to use when authorising requests to the API.
+    :param cache: When given, set up a :py:class:`CachedSession` and attempt to use the cache
+        for certain request types before calling the API.
     """
 
-    __slots__ = ("session", "__dict__")
-
-    #: The initial backoff time for failed requests
-    backoff_start = 0.5
-    #: The factor by which to increase backoff time for failed requests i.e. backoff_start ** backoff_factor
-    backoff_factor = 2
-    #: The maximum number of request attempts to make before giving up and raising an exception
-    backoff_count = 10
+    __slots__ = ("logger", "authoriser", "cache", "session", "backoff_start", "backoff_factor", "backoff_count")
 
     @property
     def backoff_final(self) -> int:
@@ -53,19 +49,27 @@ class RequestHandler(APIAuthoriser):
         """
         return sum(self.backoff_start * self.backoff_factor ** i for i in range(self.backoff_count + 1))
 
-    def __init__(self, cache_path: str | None = None, cache_expiry: ExpirationTime = timedelta(weeks=4), **auth_kwargs):
-        super().__init__(**auth_kwargs)
+    def __init__(self, authoriser: APIAuthoriser, cache: ResponseCache | None = None):
+        # noinspection PyTypeChecker
+        #: The :py:class:`MusifyLogger` for this  object
+        self.logger: MusifyLogger = logging.getLogger(__name__)
 
-        #: The :py:class:`Session` or :py:class:`CachedSession` object
-        self.session: CachedSession | Session
-        if cache_path:
-            self.logger.debug(f"Setting up requests cache: {cache_path}")
-            self.session = CachedSession(cache_path, expire_after=cache_expiry, allowable_methods=["GET"])
-        else:
-            self.session = Session()
+        #: The :py:class:`APIAuthoriser` object
+        self.authoriser = authoriser
+        #: The cache to use when attempting to return a cached response.
+        self.cache = cache
+        #: The :py:class:`Session` object
+        self.session = Session() if cache is None else CachedSession(cache=cache)
+
+        #: The initial backoff time for failed requests
+        self.backoff_start = 0.5
+        #: The factor by which to increase backoff time for failed requests i.e. backoff_start ** backoff_factor
+        self.backoff_factor = 2
+        #: The maximum number of request attempts to make before giving up and raising an exception
+        self.backoff_count = 10
 
     def authorise(self, force_load: bool = False, force_new: bool = False) -> dict[str, str]:
-        headers = super().authorise(force_load=force_load, force_new=force_new)
+        headers = self.authoriser(force_load=force_load, force_new=force_new)
         self.session.headers.update(headers)
         return headers
 
@@ -104,13 +108,14 @@ class RequestHandler(APIAuthoriser):
 
             response = self._request(method=method, url=url, *args, **kwargs)
 
+        if self.cache is not None:
+            self.cache.save_response(response)
         return self._response_as_json(response)
 
     def _request(
             self,
             method: str,
             url: str,
-            use_cache: bool = True,
             log_pad: int = 43,
             log_extra: Iterable[str] = (),
             *args,
@@ -125,9 +130,6 @@ class RequestHandler(APIAuthoriser):
             log.append(f"Args: ({', '.join(args)})")
         if len(kwargs) > 0:
             log.extend(f"{k.title()}: {v}" for k, v in kwargs.items())
-        if use_cache and isinstance(self.session, CachedSession):
-            if method.upper() in self.session.settings.allowable_methods:
-                log.append("Cached")
 
         headers = self.session.headers
         if "headers" in kwargs:
@@ -135,11 +137,7 @@ class RequestHandler(APIAuthoriser):
 
         self.logger.debug(" | ".join(log))
         try:
-            if not isinstance(self.session, CachedSession):
-                return self.session.request(method=method.upper(), url=url, headers=headers, *args, **kwargs)
-            return self.session.request(
-                method=method.upper(), force_refresh=not use_cache, url=url, headers=headers, *args, **kwargs
-            )
+            return self.session.request(method=method.upper(), url=url, headers=headers, *args, **kwargs)
         except requests.exceptions.ConnectionError as ex:
             self.logger.warning(str(ex))
             return

--- a/musify/api/request.py
+++ b/musify/api/request.py
@@ -110,8 +110,6 @@ class RequestHandler:
 
             response = self._request(method=method, url=url, *args, **kwargs)
 
-        if self.cache is not None:
-            self.cache.save_response(response)
         return self._response_as_json(response)
 
     def _request(

--- a/musify/api/request.py
+++ b/musify/api/request.py
@@ -138,7 +138,7 @@ class RequestHandler:
         if len(kwargs) > 0:
             log.extend(f"{k.title()}: {v}" for k, v in kwargs.items())
         if isinstance(self.session, CachedSession):
-            log.extend("Cached Request")
+            log.append("Cached Request")
 
         if not isinstance(self.session, CachedSession):
             clean_kwargs(self.session.request, kwargs)

--- a/musify/api/request.py
+++ b/musify/api/request.py
@@ -65,7 +65,7 @@ class RequestHandler:
         #: The initial backoff time for failed requests
         self.backoff_start = 0.5
         #: The factor by which to increase backoff time for failed requests i.e. backoff_start ** backoff_factor
-        self.backoff_factor = 2
+        self.backoff_factor = 1.5
         #: The maximum number of request attempts to make before giving up and raising an exception
         self.backoff_count = 10
 

--- a/musify/core/base.py
+++ b/musify/core/base.py
@@ -43,6 +43,8 @@ class MusifyObject(AttributePrinter):
 class MusifyItem(MusifyObject, Hashable, metaclass=ABCMeta):
     """Generic class for storing an item."""
 
+    __slots__ = ()
+
     @property
     @abstractmethod
     def uri(self) -> str | None:
@@ -76,6 +78,8 @@ class MusifyItem(MusifyObject, Hashable, metaclass=ABCMeta):
 # noinspection PyPropertyDefinition
 class MusifyItemSettable(MusifyItem, metaclass=ABCMeta):
     """Generic class for storing an item that can have select properties modified."""
+
+    __slots__ = ()
 
     @abstractmethod
     def _uri_getter(self) -> str | None:

--- a/musify/core/printer.py
+++ b/musify/core/printer.py
@@ -15,6 +15,8 @@ from musify.utils import to_collection
 class PrettyPrinter(ABC):
     """Generic base class for pretty printing. Classes can inherit this class to gain pretty print functionality."""
 
+    __slots__ = ()
+
     _upper_key_words = {"id", "uri", "url", "bpm"}
     _max_val_width = 120
 
@@ -192,6 +194,7 @@ class AttributePrinter(PrettyPrinter):
     and uses these for printer representations.
     """
 
+    __slots__ = ()
     __attributes_classes__: UnitIterable[type] = ()
     __attributes_ignore__: UnitIterable[str] = ()
 

--- a/musify/file/base.py
+++ b/musify/file/base.py
@@ -14,6 +14,8 @@ from musify.file.exception import InvalidFileType, FileDoesNotExistError
 class File(Hashable, metaclass=ABCMeta):
     """Generic class for representing a file on a system."""
 
+    __slots__ = ()
+
     #: Extensions of files that can be loaded by this class.
     valid_extensions: frozenset[str]
 

--- a/musify/file/path_mapper.py
+++ b/musify/file/path_mapper.py
@@ -16,6 +16,8 @@ class PathMapper(PrettyPrinter):
     Can be extended by child classes for more complex mapping operations.
     """
 
+    __slots__ = ()
+
     def map(self, value: str | File | None, check_existence: bool = False) -> str | None:
         """
         Map the given ``value`` by either extracting the path from a :py:class:`File` object,

--- a/musify/libraries/core/object.py
+++ b/musify/libraries/core/object.py
@@ -4,8 +4,7 @@ The core abstract implementations of :py:class:`MusifyItem` and :py:class:`Musif
 from __future__ import annotations
 
 import datetime
-import logging
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Collection, Mapping, Iterable
 from copy import deepcopy
 from typing import Self
@@ -14,13 +13,12 @@ from musify.core.base import MusifyItem
 from musify.exception import MusifyTypeError
 from musify.libraries.core.collection import MusifyCollection
 from musify.libraries.remote.core.enum import RemoteObjectType
-from musify.libraries.remote.core.processors.wrangle import RemoteDataWrangler
-from musify.log.logger import MusifyLogger
 
 
-class Track(MusifyItem, metaclass=ABCMeta):
+class Track(MusifyItem, ABC):
     """Represents a track including its metadata/tags/properties."""
 
+    __slots__ = ()
     __attributes_ignore__ = "name"
 
     # noinspection PyPropertyDefinition
@@ -169,9 +167,10 @@ class Track(MusifyItem, metaclass=ABCMeta):
         raise NotImplementedError
 
 
-class Playlist[T: Track](MusifyCollection[T], metaclass=ABCMeta):
+class Playlist[T: Track](MusifyCollection[T], ABC):
     """A playlist of items and their derived properties/objects."""
 
+    __slots__ = ()
     __attributes_classes__ = MusifyCollection
     __attributes_ignore__ = "items"
 
@@ -289,9 +288,10 @@ class Playlist[T: Track](MusifyCollection[T], metaclass=ABCMeta):
         return self
 
 
-class Library[T: Track](MusifyCollection[T], metaclass=ABCMeta):
+class Library[T: Track](MusifyCollection[T], ABC):
     """A library of items and playlists and other object types."""
 
+    __slots__ = ()
     __attributes_classes__ = MusifyCollection
     __attributes_ignore__ = "items"
 
@@ -333,13 +333,6 @@ class Library[T: Track](MusifyCollection[T], metaclass=ABCMeta):
     def playlists(self) -> dict[str, Playlist[T]]:
         """The playlists in this library"""
         raise NotImplementedError
-
-    def __init__(self, remote_wrangler: RemoteDataWrangler()):
-        super().__init__(remote_wrangler=remote_wrangler)
-
-        # noinspection PyTypeChecker
-        #: The :py:class:`MusifyLogger` for this  object
-        self.logger: MusifyLogger = logging.getLogger(__name__)
 
     @abstractmethod
     def load(self):
@@ -412,11 +405,12 @@ class Library[T: Track](MusifyCollection[T], metaclass=ABCMeta):
             self.playlists[name].merge(playlist, reference=reference.get(name))
 
 
-class Folder[T: Track](MusifyCollection[T], metaclass=ABCMeta):
+class Folder[T: Track](MusifyCollection[T], ABC):
     """
     A folder of items and their derived properties/objects
     """
 
+    __slots__ = ()
     __attributes_classes__ = MusifyCollection
     __attributes_ignore__ = ("name", "items")
 
@@ -478,9 +472,10 @@ class Folder[T: Track](MusifyCollection[T], metaclass=ABCMeta):
         return sum(lengths) if lengths else None
 
 
-class Album[T: Track](MusifyCollection[T], metaclass=ABCMeta):
+class Album[T: Track](MusifyCollection[T], ABC):
     """An album of items and their derived properties/objects."""
 
+    __slots__ = ()
     __attributes_classes__ = MusifyCollection
     __attributes_ignore__ = ("name", "items")
 
@@ -601,9 +596,10 @@ class Album[T: Track](MusifyCollection[T], metaclass=ABCMeta):
         raise NotImplementedError
 
 
-class Artist[T: (Track, Album)](MusifyCollection[T], metaclass=ABCMeta):
+class Artist[T: (Track, Album)](MusifyCollection[T], ABC):
     """An artist of items and their derived properties/objects."""
 
+    __slots__ = ()
     __attributes_classes__ = MusifyCollection
     __attributes_ignore__ = ("name", "items")
 
@@ -672,9 +668,10 @@ class Artist[T: (Track, Album)](MusifyCollection[T], metaclass=ABCMeta):
         raise NotImplementedError
 
 
-class Genre[T: Track](MusifyCollection[T], metaclass=ABCMeta):
+class Genre[T: Track](MusifyCollection[T], ABC):
     """A genre of items and their derived properties/objects."""
 
+    __slots__ = ()
     __attributes_classes__ = MusifyCollection
     __attributes_ignore__ = ("name", "items")
 

--- a/musify/libraries/local/base.py
+++ b/musify/libraries/local/base.py
@@ -1,13 +1,14 @@
 """
 Core abstract classes for the :py:mod:`Local` module.
 """
-from abc import ABCMeta
+from abc import ABC
 
 from musify.core.base import MusifyItemSettable
 from musify.file.base import File
 
 
-class LocalItem(File, MusifyItemSettable, metaclass=ABCMeta):
+class LocalItem(File, MusifyItemSettable, ABC):
     """Generic base class for locally-stored items"""
 
+    __slots__ = ()
     __attributes_classes__ = (File, MusifyItemSettable)

--- a/musify/libraries/local/collection.py
+++ b/musify/libraries/local/collection.py
@@ -32,11 +32,11 @@ class LocalCollection[T: LocalTrack](MusifyCollection[T], metaclass=ABCMeta):
     """
     Generic class for storing a collection of local tracks.
 
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs on items.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs on items.
         If given, the wrangler can be used when calling __get_item__ to get an item from the collection from its URI.
     """
 
-    __slots__ = ("logger", "remote_wrangler")
+    __slots__ = ("logger",)
     __attributes_ignore__ = ("track_paths", "track_total")
 
     @staticmethod
@@ -179,7 +179,7 @@ class LocalCollectionFiltered[T: LocalItem](LocalCollection[T], metaclass=ABCMet
         If None, the list of tracks given are taken to be all the tracks contained in this collection.
     :raise LocalCollectionError: If the given tracks contain more than one unique value
         for the attribute of this collection when name is None.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs on tracks.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs on tracks.
         If given, the wrangler can be used when calling __get_item__ to get an item from the collection from its URI.
     """
 
@@ -252,7 +252,7 @@ class LocalFolder(LocalCollectionFiltered[LocalTrack], Folder[LocalTrack]):
     :param name: The name of this folder.
         If given, the object only stores tracks that match the folder ``name`` given.
         If None, the list of tracks given are taken to be all the tracks contained in this folder.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs on tracks.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs on tracks.
         If given, the wrangler can be used when calling __get_item__ to get an item from the collection from its URI.
     :raise LocalCollectionError: If the given tracks contain more than one unique value for
         ``folder`` when name is None.
@@ -291,7 +291,7 @@ class LocalAlbum(LocalCollectionFiltered[LocalTrack], Album[LocalTrack]):
     :param name: The name of this album.
         If given, the object only stores tracks that match the album ``name`` given.
         If None, the list of tracks given are taken to be all the tracks for this album.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs on tracks.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs on tracks.
         If given, the wrangler can be used when calling __get_item__ to get an item from the collection from its URI.
     :raise LocalCollectionError: If the given tracks contain more than one unique value for
         ``album`` when name is None.
@@ -373,7 +373,7 @@ class LocalArtist(LocalCollectionFiltered[LocalTrack], Artist[LocalTrack]):
     :param name: The name of this artist.
         If given, the object only stores tracks that match the artist ``name`` given.
         If None, the list of tracks given are taken to be all the tracks by this artist.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs on tracks.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs on tracks.
         If given, the wrangler can be used when calling __get_item__ to get an item from the collection from its URI.
     :raise LocalCollectionError: If the given tracks contain more than one unique value for
         ``artist`` when name is None.
@@ -411,7 +411,7 @@ class LocalGenres(LocalCollectionFiltered[LocalTrack], Genre[LocalTrack]):
     :param name: The name of this genre.
         If given, the object only stores tracks that match the genre ``name`` given.
         If None, the list of tracks given are taken to be all the tracks within this genre.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs on tracks.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs on tracks.
         If given, the wrangler can be used when calling __get_item__ to get an item from the collection from its URI.
     :raise LocalCollectionError: If the given tracks contain more than one unique value for
         ``genre`` when name is None.

--- a/musify/libraries/local/library/library.py
+++ b/musify/libraries/local/library/library.py
@@ -57,6 +57,7 @@ class LocalLibrary(LocalCollection[LocalTrack], Library[LocalTrack]):
         "_playlists",
         "_track_paths",
         "_tracks",
+        "errors",
     )
     __attributes_classes__ = (Library, LocalCollection)
     __attributes_ignore__ = ("tracks_in_playlists",)

--- a/musify/libraries/local/library/musicbee.py
+++ b/musify/libraries/local/library/musicbee.py
@@ -49,7 +49,7 @@ class MusicBee(LocalLibrary, File):
         "library_xml",
         "_library_xml_path",
         "_library_xml_parser",
-        "settings_xml"
+        "settings_xml",
         "_settings_xml_path",
         "_settings_xml_parser",
     )

--- a/musify/libraries/local/library/musicbee.py
+++ b/musify/libraries/local/library/musicbee.py
@@ -38,7 +38,7 @@ class MusicBee(LocalLibrary, File):
     :param path_mapper: Optionally, provide a :py:class:`PathMapper` for paths stored in the playlist files.
         Useful if the playlist files contain relative paths and/or paths for other systems that need to be
         mapped to absolute, system-specific paths to be loaded and back again when saved.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs on tracks.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs on tracks.
         If given, the wrangler can be used when calling __get_item__ to get an item from the collection from its URI.
         The wrangler is also used when loading tracks to allow them to process URI tags.
         For more info on this, see :py:class:`LocalTrack`.

--- a/musify/libraries/local/playlist/base.py
+++ b/musify/libraries/local/playlist/base.py
@@ -29,7 +29,7 @@ class LocalPlaylist[T: Filter[LocalTrack]](LocalCollection[LocalTrack], Playlist
     :param path_mapper: Optionally, provide a :py:class:`PathMapper` for paths stored in the playlist file.
         Useful if the playlist file contains relative paths and/or paths for other systems that need to be
         mapped to absolute, system-specific paths to be loaded and back again when saved.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs on tracks.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs on tracks.
         If given, the wrangler can be used when calling __get_item__ to get an item from the collection from its URI.
         The wrangler is also used when loading tracks to allow them to process URI tags.
         For more info on this, see :py:class:`LocalTrack`.

--- a/musify/libraries/local/playlist/base.py
+++ b/musify/libraries/local/playlist/base.py
@@ -1,7 +1,7 @@
 """
 Base implementation for the functionality of a local playlist.
 """
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Collection
 from datetime import datetime
 from os.path import dirname, join, getmtime, getctime, exists
@@ -18,7 +18,7 @@ from musify.processors.limit import ItemLimiter
 from musify.processors.sort import ItemSorter
 
 
-class LocalPlaylist[T: Filter[LocalTrack]](LocalCollection[LocalTrack], Playlist[LocalTrack], File, metaclass=ABCMeta):
+class LocalPlaylist[T: Filter[LocalTrack]](LocalCollection[LocalTrack], Playlist[LocalTrack], File, ABC):
     """
     Generic class for loading and manipulating local playlists.
 

--- a/musify/libraries/local/playlist/m3u.py
+++ b/musify/libraries/local/playlist/m3u.py
@@ -47,7 +47,7 @@ class M3U(LocalPlaylist[FilterDefinedList[str | File]]):
     :param path_mapper: Optionally, provide a :py:class:`PathMapper` for paths stored in the playlist file.
         Useful if the playlist file contains relative paths and/or paths for other systems that need to be
         mapped to absolute, system-specific paths to be loaded and back again when saved.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs on tracks.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs on tracks.
         If given, the wrangler can be used when calling __get_item__ to get an item from the collection from its URI.
         The wrangler is also used when loading tracks to allow them to process URI tags.
         For more info on this, see :py:class:`LocalTrack`.

--- a/musify/libraries/local/playlist/utils.py
+++ b/musify/libraries/local/playlist/utils.py
@@ -36,7 +36,7 @@ def load_playlist(
     :param path_mapper: Optionally, provide a :py:class:`PathMapper` for paths stored in the playlist file.
         Useful if the playlist file contains relative paths and/or paths for other systems that need to be
         mapped to absolute, system-specific paths to be loaded and back again when saved.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs on tracks.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs on tracks.
         If given, the wrangler can be used when calling __get_item__ to get an item from the collection from its URI.
         The wrangler is also used when loading tracks to allow them to process URI tags.
         For more info on this, see :py:class:`LocalTrack`.

--- a/musify/libraries/local/playlist/xautopf.py
+++ b/musify/libraries/local/playlist/xautopf.py
@@ -75,7 +75,7 @@ class XAutoPF(LocalPlaylist[AutoMatcher]):
         mapped to absolute, system-specific paths to be loaded and back again when saved.
     """
 
-    __slots__ = ("_parser",)
+    __slots__ = ("_parser", "_limiter_deduplication")
 
     valid_extensions = frozenset({".xautopf"})
 
@@ -210,7 +210,7 @@ class XAutoPF(LocalPlaylist[AutoMatcher]):
 
 class XMLPlaylistParser(File, PrettyPrinter):
 
-    __slots__ = ("_path", "path_mapper", "xml",)
+    __slots__ = ("_path", "path_mapper", "xml")
 
     # noinspection SpellCheckingInspection
     #: Map of MusicBee field key name to Field enum

--- a/musify/libraries/local/track/flac.py
+++ b/musify/libraries/local/track/flac.py
@@ -94,7 +94,7 @@ class FLACTagWriter(TagWriter[mutagen.flac.FLAC]):
 
 class FLAC(LocalTrack[mutagen.flac.FLAC, FLACTagReader, FLACTagWriter]):
 
-    __slots__ = LocalTrack.__slots__  # TODO: This shouldn't be needed? Breaks tests without it
+    __slots__ = ()
 
     valid_extensions = frozenset({".flac"})
 

--- a/musify/libraries/local/track/flac.py
+++ b/musify/libraries/local/track/flac.py
@@ -19,6 +19,8 @@ from musify.libraries.local.track.track import LocalTrack
 
 class FLACTagReader(TagReader[mutagen.flac.FLAC]):
 
+    __slots__ = ()
+
     def read_images(self) -> list[Image.Image] | None:
         values = self.file.pictures
         return [Image.open(BytesIO(value.data)) for value in values] if len(values) > 0 else None
@@ -28,6 +30,8 @@ class FLACTagReader(TagReader[mutagen.flac.FLAC]):
 
 
 class FLACTagWriter(TagWriter[mutagen.flac.FLAC]):
+
+    __slots__ = ()
 
     def write_tag(self, tag_id: str | None, tag_value: Any, dry_run: bool = True) -> bool:
         result = super().write_tag(tag_id=tag_id, tag_value=tag_value, dry_run=dry_run)
@@ -89,6 +93,8 @@ class FLACTagWriter(TagWriter[mutagen.flac.FLAC]):
 
 
 class FLAC(LocalTrack[mutagen.flac.FLAC, FLACTagReader, FLACTagWriter]):
+
+    __slots__ = LocalTrack.__slots__  # TODO: This shouldn't be needed? Breaks tests without it
 
     valid_extensions = frozenset({".flac"})
 

--- a/musify/libraries/local/track/m4a.py
+++ b/musify/libraries/local/track/m4a.py
@@ -19,6 +19,8 @@ from musify.utils import to_collection
 
 class M4ATagReader(TagReader[mutagen.mp4.MP4]):
 
+    __slots__ = ()
+
     def read_tag(self, tag_ids: Iterable[str]) -> list[Any] | None:
         """Extract all tag values for a given list of tag IDs"""
         values = []
@@ -63,6 +65,8 @@ class M4ATagReader(TagReader[mutagen.mp4.MP4]):
 
 
 class M4ATagWriter(TagWriter[mutagen.mp4.MP4]):
+
+    __slots__ = ()
 
     def write_tag(self, tag_id: str | None, tag_value: Any, dry_run: bool = True) -> bool:
         result = super().write_tag(tag_id=tag_id, tag_value=tag_value, dry_run=dry_run)
@@ -136,6 +140,8 @@ class M4ATagWriter(TagWriter[mutagen.mp4.MP4]):
 
 
 class M4A(LocalTrack[mutagen.mp4.MP4, M4ATagReader, M4ATagWriter]):
+
+    __slots__ = LocalTrack.__slots__  # TODO: This shouldn't be needed? Breaks tests without it
 
     valid_extensions = frozenset({".m4a"})
 

--- a/musify/libraries/local/track/m4a.py
+++ b/musify/libraries/local/track/m4a.py
@@ -141,7 +141,7 @@ class M4ATagWriter(TagWriter[mutagen.mp4.MP4]):
 
 class M4A(LocalTrack[mutagen.mp4.MP4, M4ATagReader, M4ATagWriter]):
 
-    __slots__ = LocalTrack.__slots__  # TODO: This shouldn't be needed? Breaks tests without it
+    __slots__ = ()
 
     valid_extensions = frozenset({".m4a"})
 

--- a/musify/libraries/local/track/mp3.py
+++ b/musify/libraries/local/track/mp3.py
@@ -21,6 +21,8 @@ from musify.libraries.local.track.track import LocalTrack
 
 class MP3TagReader(TagReader[mutagen.mp3.MP3]):
 
+    __slots__ = ()
+
     def read_tag(self, tag_ids: Iterable[str]) -> list[Any] | None:
         # MP3 tag ids come in parts separated by : i.e. 'COMM:ID3v1 Comment:eng'
         # need to search all actual MP3 tag ids to check if the first part equals any of the given base tag ids
@@ -55,6 +57,8 @@ class MP3TagReader(TagReader[mutagen.mp3.MP3]):
 
 
 class MP3TagWriter(TagWriter[mutagen.mp3.MP3]):
+
+    __slots__ = ()
 
     def delete_tag(self, tag_name: str, dry_run: bool = True) -> bool:
         removed = False
@@ -153,6 +157,8 @@ class MP3TagWriter(TagWriter[mutagen.mp3.MP3]):
 
 
 class MP3(LocalTrack[mutagen.mp3.MP3, MP3TagReader, MP3TagWriter]):
+
+    __slots__ = LocalTrack.__slots__  # TODO: This shouldn't be needed? Breaks tests without it
 
     valid_extensions = frozenset({".mp3"})
 

--- a/musify/libraries/local/track/mp3.py
+++ b/musify/libraries/local/track/mp3.py
@@ -158,7 +158,7 @@ class MP3TagWriter(TagWriter[mutagen.mp3.MP3]):
 
 class MP3(LocalTrack[mutagen.mp3.MP3, MP3TagReader, MP3TagWriter]):
 
-    __slots__ = LocalTrack.__slots__  # TODO: This shouldn't be needed? Breaks tests without it
+    __slots__ = ()
 
     valid_extensions = frozenset({".mp3"})
 

--- a/musify/libraries/local/track/tags/base.py
+++ b/musify/libraries/local/track/tags/base.py
@@ -22,6 +22,8 @@ class TagProcessor[T: mutagen.FileType](ABC):
         If no ``remote_wrangler`` is given, no URI processing will occur.
     """
 
+    __slots__ = ("file", "tag_map", "remote_wrangler")
+
     #: The tag field to use as the URI tag in the file's metadata
     uri_tag: LocalTrackField = LocalTrackField.COMMENTS
     #: The separator to use when representing separated tag values as a combined string.

--- a/musify/libraries/local/track/tags/reader.py
+++ b/musify/libraries/local/track/tags/reader.py
@@ -2,7 +2,7 @@
 Implements all functionality pertaining to reading metadata/tags/properties for a :py:class:`LocalTrack`.
 """
 import re
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Any
 
@@ -14,8 +14,10 @@ from musify.libraries.remote.core.enum import RemoteIDType
 from musify.utils import to_collection
 
 
-class TagReader[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
+class TagReader[T: mutagen.FileType](TagProcessor, ABC):
     """Functionality for reading tags/metadata/properties from a mutagen object."""
+
+    __slots__ = ()
 
     def read_tag(self, tag_ids: Iterable[str]) -> list[Any] | None:
         """Extract all tag values from file for a given list of tag IDs"""

--- a/musify/libraries/local/track/tags/writer.py
+++ b/musify/libraries/local/track/tags/writer.py
@@ -1,7 +1,7 @@
 """
 Implements all functionality pertaining to writing and deleting metadata/tags/properties for a :py:class:`LocalTrack`.
 """
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Mapping, Collection, Callable
 from dataclasses import dataclass
 from typing import Any
@@ -25,8 +25,10 @@ class SyncResultTrack(Result):
     updated: Mapping[Tags, int]
 
 
-class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
+class TagWriter[T: mutagen.FileType](TagProcessor, ABC):
     """Functionality for updating and removing tags/metadata/properties from a mutagen object."""
+
+    __slots__ = ()
 
     #: The date format to use when saving string representations of dates to tag values
     date_format = "%Y-%m-%d"

--- a/musify/libraries/local/track/track.py
+++ b/musify/libraries/local/track/track.py
@@ -3,7 +3,7 @@ Compositely combine reader and writer classes for metadata/tags/properties opera
 """
 import datetime
 import os
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from copy import deepcopy
 from os.path import join, exists, dirname
 from typing import Any, Self
@@ -25,7 +25,7 @@ from musify.types import UnitIterable
 from musify.utils import to_collection
 
 
-class LocalTrack[T: mutagen.FileType, U: TagReader, V: TagWriter](LocalItem, Track, metaclass=ABCMeta):
+class LocalTrack[T: mutagen.FileType, U: TagReader, V: TagWriter](LocalItem, Track, ABC):
     """
     Generic track object for extracting, modifying, and saving metadata/tags/properties for a given file.
 

--- a/musify/libraries/local/track/track.py
+++ b/musify/libraries/local/track/track.py
@@ -30,7 +30,7 @@ class LocalTrack[T: mutagen.FileType, U: TagReader, V: TagWriter](LocalItem, Tra
     Generic track object for extracting, modifying, and saving metadata/tags/properties for a given file.
 
     :param file: The path or Mutagen object of the file to load.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs.
         This object will be used to check for and validate a URI tag on the file.
         The tag that is used for reading and writing is set by the ``uri_tag`` class attribute.
         If no ``remote_wrangler`` is given, no URI processing will occur.

--- a/musify/libraries/local/track/utils.py
+++ b/musify/libraries/local/track/utils.py
@@ -23,7 +23,7 @@ def load_track(path: str, remote_wrangler: RemoteDataWrangler = None) -> LocalTr
     Attempt to load a file from a given path, returning the appropriate :py:class:`LocalTrack` object
 
     :param path: The path of the file to load.
-    :param remote_wrangler: Optionally, provide a RemoteDataWrangler object for processing URIs.
+    :param remote_wrangler: Optionally, provide a :py:class:`RemoteDataWrangler` object for processing URIs.
         This object will be used to check for and validate a URI tag on the file.
         The tag that is used for reading and writing is set by the ``uri_tag`` class attribute on the track object.
         If no ``remote_wrangler`` is given, no URI processing will occur.

--- a/musify/libraries/local/track/wma.py
+++ b/musify/libraries/local/track/wma.py
@@ -20,6 +20,8 @@ from musify.libraries.local.track.track import LocalTrack
 
 class WMATagReader(TagReader[mutagen.asf.ASF]):
 
+    __slots__ = ()
+
     def read_tag(self, tag_ids: Iterable[str]) -> list[Any] | None:
         # WMA tag values are returned as mutagen.asf._attrs.ASFUnicodeAttribute
         values = []
@@ -73,6 +75,8 @@ class WMATagReader(TagReader[mutagen.asf.ASF]):
 
 class WMATagWriter(TagWriter[mutagen.asf.ASF]):
 
+    __slots__ = ()
+
     def write_tag(self, tag_id: str | None, tag_value: Any, dry_run: bool = True) -> bool:
         result = super().write_tag(tag_id=tag_id, tag_value=tag_value, dry_run=dry_run)
         if result is not None:
@@ -115,6 +119,8 @@ class WMATagWriter(TagWriter[mutagen.asf.ASF]):
 
 
 class WMA(LocalTrack[mutagen.asf.ASF, WMATagReader, WMATagWriter]):
+
+    __slots__ = LocalTrack.__slots__  # TODO: This shouldn't be needed? Breaks tests without it
 
     valid_extensions = frozenset({".wma"})
 

--- a/musify/libraries/local/track/wma.py
+++ b/musify/libraries/local/track/wma.py
@@ -120,7 +120,7 @@ class WMATagWriter(TagWriter[mutagen.asf.ASF]):
 
 class WMA(LocalTrack[mutagen.asf.ASF, WMATagReader, WMATagWriter]):
 
-    __slots__ = LocalTrack.__slots__  # TODO: This shouldn't be needed? Breaks tests without it
+    __slots__ = ()
 
     valid_extensions = frozenset({".wma"})
 

--- a/musify/libraries/remote/core/api.py
+++ b/musify/libraries/remote/core/api.py
@@ -72,8 +72,6 @@ class RemoteAPI(ABC):
         return self.wrangler.source
 
     def __init__(self, authoriser: APIAuthoriser, wrangler: RemoteDataWrangler, cache: ResponseCache | None = None):
-        super().__init__()
-
         # noinspection PyTypeChecker
         #: The :py:class:`MusifyLogger` for this  object
         self.logger: MusifyLogger = logging.getLogger(__name__)

--- a/musify/libraries/remote/core/api.py
+++ b/musify/libraries/remote/core/api.py
@@ -76,6 +76,8 @@ class RemoteAPI(ABC):
         #: The :py:class:`MusifyLogger` for this  object
         self.logger: MusifyLogger = logging.getLogger(__name__)
 
+        self._setup_cache(cache)
+
         #: A :py:class:`RemoteDataWrangler` object for processing URIs
         self.wrangler = wrangler
         #: The :py:class:`RequestHandler` for handling authorised requests to the API
@@ -83,6 +85,11 @@ class RemoteAPI(ABC):
 
         #: Stores the loaded user data for the currently authorised user
         self.user_data: dict[str, Any] = {}
+
+    @abstractmethod
+    def _setup_cache(self, cache: ResponseCache) -> None:
+        """Set up the repositories and repository getter on the given ``cache``."""
+        raise NotImplementedError
 
     def authorise(self, force_load: bool = False, force_new: bool = False) -> Self:
         """

--- a/musify/libraries/remote/core/api.py
+++ b/musify/libraries/remote/core/api.py
@@ -29,7 +29,7 @@ class RemoteAPI(ABC):
     :param wrangler: The :py:class:`RemoteDataWrangler` for this API type.
     :param authoriser: The authoriser to use when authorising requests to the API.
     :param cache: When given, attempt to use this cache for certain request types before calling the API.
-        Cache storage and cachable request types can be set up by child classes.
+        Repository and cachable request types can be set up by child classes.
     """
 
     __slots__ = ("logger", "handler", "wrangler", "user_data")

--- a/musify/libraries/remote/core/api.py
+++ b/musify/libraries/remote/core/api.py
@@ -8,6 +8,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Collection, MutableMapping, Mapping, Sequence
 from typing import Any, Self
 
+from musify.api.authorise import APIAuthoriser
+from musify.api.cache.backend.base import ResponseCache
 from musify.api.request import RequestHandler
 from musify.libraries.remote.core import RemoteResponse
 from musify.libraries.remote.core.enum import RemoteIDType, RemoteObjectType
@@ -24,10 +26,13 @@ class RemoteAPI(ABC):
     See :py:class:`RequestHandler` and :py:class:`APIAuthoriser`
     for more info on which params to pass to authorise and execute requests.
 
-    :param handler_kwargs: The authorisation kwargs to be passed to :py:class:`APIAuthoriser`.
+    :param wrangler: The :py:class:`RemoteDataWrangler` for this API type.
+    :param authoriser: The authoriser to use when authorising requests to the API.
+    :param cache: When given, attempt to use this cache for certain request types before calling the API.
+        Cache storage and cachable request types can be set up by child classes.
     """
 
-    __slots__ = ("logger", "handler", "user_data", "wrangler")
+    __slots__ = ("logger", "handler", "wrangler", "user_data")
 
     #: Map of :py:class:`RemoteObjectType` for remote collections
     #: to the  :py:class:`RemoteObjectType` of the items they hold
@@ -66,19 +71,17 @@ class RemoteAPI(ABC):
         """The name of the API service"""
         return self.wrangler.source
 
-    def __init__(self, wrangler: RemoteDataWrangler, **handler_kwargs):
+    def __init__(self, authoriser: APIAuthoriser, wrangler: RemoteDataWrangler, cache: ResponseCache | None = None):
         super().__init__()
-        #: A :py:class:`RemoteDataWrangler` object for processing URIs
-        self.wrangler = wrangler
 
         # noinspection PyTypeChecker
         #: The :py:class:`MusifyLogger` for this  object
         self.logger: MusifyLogger = logging.getLogger(__name__)
 
+        #: A :py:class:`RemoteDataWrangler` object for processing URIs
+        self.wrangler = wrangler
         #: The :py:class:`RequestHandler` for handling authorised requests to the API
-        self.handler = RequestHandler(
-            name=self.wrangler.source, **{k: v for k, v in handler_kwargs.items() if k != "name"}
-        )
+        self.handler = RequestHandler(authoriser=authoriser, cache=cache)
 
         #: Stores the loaded user data for the currently authorised user
         self.user_data: dict[str, Any] = {}
@@ -210,7 +213,6 @@ class RemoteAPI(ABC):
             value: str | Mapping[str, Any] | RemoteResponse | None = None,
             kind: RemoteIDType | None = None,
             limit: int = 20,
-            use_cache: bool = True
     ) -> None:
         """
         Pretty print collection data for displaying to the user.
@@ -226,21 +228,17 @@ class RemoteAPI(ABC):
             If None and ID is given, user will be prompted to give the kind anyway.
         :param limit: The number of results to call per request and,
             therefore, the number of items in each printed block.
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         """
         raise NotImplementedError
 
     @abstractmethod
-    def get_playlist_url(self, playlist: str | Mapping[str, Any] | RemoteResponse, use_cache: bool = True) -> str:
+    def get_playlist_url(self, playlist: str | Mapping[str, Any] | RemoteResponse) -> str:
         """
         Determine the type of the given ``playlist`` and return its API URL.
         If type cannot be determined, attempt to find the playlist in the
         list of the currently authenticated user's playlists.
 
         :param playlist: In URL/URI/ID form, or the name of one of the currently authenticated user's playlists.
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         :return: The playlist URL.
         :raise RemoteIDTypeError: Raised when the function cannot determine the item type of
             the input ``playlist``. Or when it does not recognise the type of the input ``playlist`` parameter.
@@ -259,17 +257,13 @@ class RemoteAPI(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def query(
-            self, query: str, kind: RemoteObjectType, limit: int = 10, use_cache: bool = True
-    ) -> list[dict[str, Any]]:
+    def query(self, query: str, kind: RemoteObjectType, limit: int = 10) -> list[dict[str, Any]]:
         """
         ``GET`` - Query for items. Modify result types returned with kind parameter
 
         :param query: Search query.
         :param kind: The remote object type to search for.
         :param limit: Number of results to get and return.
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         :return: The response from the endpoint.
         """
         raise NotImplementedError
@@ -283,7 +277,6 @@ class RemoteAPI(ABC):
             response: MutableMapping[str, Any] | RemoteResponse,
             kind: RemoteObjectType | str | None = None,
             key: RemoteObjectType | None = None,
-            use_cache: bool = True,
     ) -> list[dict[str, Any]]:
         """
         Extend the items for a given API ``response``.
@@ -298,8 +291,6 @@ class RemoteAPI(ABC):
         :param response: A remote API JSON response for an items type endpoint.
         :param kind: The type of response being extended. Optional, used only for logging.
         :param key: The type of response of the child objects.
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         :return: API JSON responses for each item
         """
         raise NotImplementedError
@@ -311,7 +302,6 @@ class RemoteAPI(ABC):
             kind: RemoteObjectType | None = None,
             limit: int = 50,
             extend: bool = True,
-            use_cache: bool = True,
     ) -> list[dict[str, Any]]:
         """
         ``GET`` - Get information for given ``values``.
@@ -336,8 +326,6 @@ class RemoteAPI(ABC):
             This value will be limited to be between ``1`` and ``50``.
         :param extend: When True and the given ``kind`` is a collection of items,
             extend the response to include all items in this collection.
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         :return: API JSON responses for each item.
         :raise RemoteObjectTypeError: Raised when the function cannot determine the item type
             of the input ``values``. Or when it does not recognise the type of the input ``values`` parameter.
@@ -345,9 +333,7 @@ class RemoteAPI(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_tracks(
-            self, values: APIInputValue, limit: int = 50, use_cache: bool = True, *args, **kwargs,
-    ) -> list[dict[str, Any]]:
+    def get_tracks(self, values: APIInputValue, limit: int = 50, *args, **kwargs) -> list[dict[str, Any]]:
         """
         Wrapper for :py:meth:`get_items` which only returns Track type responses.
         See :py:meth:`get_items` for more info.
@@ -356,11 +342,7 @@ class RemoteAPI(ABC):
 
     @abstractmethod
     def get_user_items(
-            self,
-            user: str | None = None,
-            kind: RemoteObjectType = RemoteObjectType.PLAYLIST,
-            limit: int = 50,
-            use_cache: bool = True,
+            self, user: str | None = None, kind: RemoteObjectType = RemoteObjectType.PLAYLIST, limit: int = 50,
     ) -> list[dict[str, Any]]:
         """
         ``GET`` - Get saved items for a given user.
@@ -369,8 +351,6 @@ class RemoteAPI(ABC):
         :param kind: Item type to retrieve for the user.
         :param limit: Size of each batch of items to request in the collection items request.
             This value will be limited to be between ``1`` and ``50``.
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         :return: API JSON responses for each collection.
         :raise RemoteIDTypeError: Raised when the input ``user`` does not represent a user URL/URI/ID.
         :raise RemoteObjectTypeError: When the given ``kind`` is not a valid user item/collection.

--- a/musify/libraries/remote/core/base.py
+++ b/musify/libraries/remote/core/base.py
@@ -86,12 +86,7 @@ class RemoteObject[T: (RemoteAPI | None)](RemoteResponse, metaclass=ABCMeta):
     @classmethod
     @abstractmethod
     def load(
-            cls,
-            value: str | Mapping[str, Any] | RemoteResponse,
-            api: RemoteAPI,
-            use_cache: bool = True,
-            *args,
-            **kwargs
+            cls, value: str | Mapping[str, Any] | RemoteResponse, api: RemoteAPI, *args, **kwargs
     ) -> Self:
         """
         Generate a new object of this class,
@@ -105,19 +100,14 @@ class RemoteObject[T: (RemoteAPI | None)](RemoteResponse, metaclass=ABCMeta):
 
         :param value: The value representing some remote object. See description for allowed value types.
         :param api: An authorised API object to load the object from.
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         """
         raise NotImplementedError
 
     @abstractmethod
-    def reload(self, use_cache: bool = True, *args, **kwargs) -> None:
+    def reload(self, *args, **kwargs) -> None:
         """
         Reload this object from the API, calling all required endpoints
         to get a complete set of data for this item type.
-
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         """
         raise NotImplementedError
 

--- a/musify/libraries/remote/core/base.py
+++ b/musify/libraries/remote/core/base.py
@@ -3,7 +3,7 @@ Core abstract classes for the :py:mod:`Remote` module.
 
 These define the foundations of any remote object or item.
 """
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import Any, Self
 
@@ -13,7 +13,7 @@ from musify.libraries.remote.core import RemoteResponse
 from musify.libraries.remote.core.api import RemoteAPI
 
 
-class RemoteObject[T: (RemoteAPI | None)](RemoteResponse, metaclass=ABCMeta):
+class RemoteObject[T: (RemoteAPI | None)](RemoteResponse, ABC):
     """
     Generic base class for remote objects. Extracts key data from a remote API JSON response.
 
@@ -116,7 +116,7 @@ class RemoteObject[T: (RemoteAPI | None)](RemoteResponse, metaclass=ABCMeta):
         return hash(self.uri)
 
 
-class RemoteItem(RemoteObject, MusifyItem, metaclass=ABCMeta):
+class RemoteItem(RemoteObject, MusifyItem, ABC):
     """Generic base class for remote items. Extracts key data from a remote API JSON response."""
 
     __attributes_classes__ = (RemoteObject, MusifyItem)

--- a/musify/libraries/remote/core/library.py
+++ b/musify/libraries/remote/core/library.py
@@ -1,7 +1,8 @@
 """
 Functionality relating to a generic remote library.
 """
-from abc import ABCMeta, abstractmethod
+import logging
+from abc import ABC, abstractmethod
 from collections.abc import Collection, Mapping, Iterable
 from typing import Any, Literal
 
@@ -13,6 +14,7 @@ from musify.libraries.remote.core.factory import RemoteObjectFactory
 from musify.libraries.remote.core.object import RemoteCollection, SyncResultRemotePlaylist
 from musify.libraries.remote.core.object import RemoteTrack, RemotePlaylist, RemoteArtist, RemoteAlbum
 from musify.log import STAT
+from musify.log.logger import MusifyLogger
 from musify.processors.base import Filter
 from musify.processors.filter import FilterDefinedList
 from musify.utils import align_string, get_max_width
@@ -20,7 +22,7 @@ from musify.utils import align_string, get_max_width
 
 class RemoteLibrary[
     A: RemoteAPI, PL: RemotePlaylist, TR: RemoteTrack, AL: RemoteAlbum, AR: RemoteArtist
-](RemoteCollection[TR], Library[TR], metaclass=ABCMeta):
+](RemoteCollection[TR], Library[TR], ABC):
     """
     Represents a remote library, providing various methods for manipulating
     tracks and playlists across an entire remote library collection.
@@ -30,7 +32,7 @@ class RemoteLibrary[
         loading playlists. Playlist names will be passed to this filter to limit which playlists are loaded.
     """
 
-    __slots__ = ("_factory", "_playlists", "_tracks", "_albums", "_artists", "playlist_filter")
+    __slots__ = ("logger", "_factory", "_playlists", "_tracks", "_albums", "_artists", "playlist_filter")
     __attributes_classes__ = (Library, RemoteCollection)
     __attributes_ignore__ = ("api", "factory")
 
@@ -79,7 +81,11 @@ class RemoteLibrary[
         return self._albums
 
     def __init__(self, api: A, playlist_filter: Collection[str] | Filter[str] = ()):
-        super().__init__(remote_wrangler=api.wrangler)
+        super().__init__()
+
+        # noinspection PyTypeChecker
+        #: The :py:class:`MusifyLogger` for this  object
+        self.logger: MusifyLogger = logging.getLogger(__name__)
 
         if not isinstance(playlist_filter, Filter):
             playlist_filter = FilterDefinedList(playlist_filter)

--- a/musify/libraries/remote/core/library.py
+++ b/musify/libraries/remote/core/library.py
@@ -28,11 +28,9 @@ class RemoteLibrary[
     :param api: The instantiated and authorised API object for this source type.
     :param playlist_filter: An optional :py:class:`Filter` to apply or collection of playlist names to include when
         loading playlists. Playlist names will be passed to this filter to limit which playlists are loaded.
-    :param use_cache: Use the cache when calling the API endpoint.
-        When using a CachedSession, set as False to refresh the cached response.
     """
 
-    __slots__ = ("_factory", "_tracks", "_playlists", "playlist_filter")
+    __slots__ = ("_factory", "_playlists", "_tracks", "_albums", "_artists", "playlist_filter")
     __attributes_classes__ = (Library, RemoteCollection)
     __attributes_ignore__ = ("api", "factory")
 
@@ -80,11 +78,8 @@ class RemoteLibrary[
         """All user's saved albums"""
         return self._albums
 
-    def __init__(self, api: A, use_cache: bool = True, playlist_filter: Collection[str] | Filter[str] = ()):
+    def __init__(self, api: A, playlist_filter: Collection[str] | Filter[str] = ()):
         super().__init__(remote_wrangler=api.wrangler)
-
-        #: When true, use the cache when calling the API endpoint
-        self.use_cache = use_cache
 
         if not isinstance(playlist_filter, Filter):
             playlist_filter = FilterDefinedList(playlist_filter)
@@ -123,7 +118,7 @@ class RemoteLibrary[
             f"with {len(load_uris)} additional tracks \33[0m"
         )
 
-        load_tracks = self.api.get_tracks(load_uris, features=True, use_cache=self.use_cache)
+        load_tracks = self.api.get_tracks(load_uris, features=True)
         self.items.extend(map(self.factory.track, load_tracks))
 
         self.logger.print(STAT)
@@ -161,14 +156,14 @@ class RemoteLibrary[
         self.logger.debug(f"Load {self.api.source} playlists: START")
         self.api.load_user_data()
 
-        responses = self.api.get_user_items(kind=RemoteObjectType.PLAYLIST, use_cache=self.use_cache)
+        responses = self.api.get_user_items(kind=RemoteObjectType.PLAYLIST)
         responses = self._filter_playlists(responses)
 
         self.logger.info(
             f"\33[1;95m  >\33[1;97m Getting {self._get_total_tracks(responses=responses)} "
             f"{self.api.source} tracks from {len(responses)} playlists \33[0m"
         )
-        self.api.get_items(responses, kind=RemoteObjectType.PLAYLIST, use_cache=self.use_cache)
+        self.api.get_items(responses, kind=RemoteObjectType.PLAYLIST)
 
         playlists = [
             self.factory.playlist(response=r, skip_checks=False)
@@ -213,7 +208,7 @@ class RemoteLibrary[
         self.logger.debug(f"Load user's saved {self.api.source} tracks: START")
         self.api.load_user_data()
 
-        responses = self.api.get_user_items(kind=RemoteObjectType.TRACK, use_cache=self.use_cache)
+        responses = self.api.get_user_items(kind=RemoteObjectType.TRACK)
         for response in self.logger.get_progress_bar(iterable=responses, desc="Processing tracks", unit="tracks"):
             track = self.factory.track(response=response, skip_checks=True)
 
@@ -261,7 +256,7 @@ class RemoteLibrary[
         self.logger.debug(f"Load user's saved {self.api.source} albums: START")
         self.api.load_user_data()
 
-        responses = self.api.get_user_items(kind=RemoteObjectType.ALBUM, use_cache=self.use_cache)
+        responses = self.api.get_user_items(kind=RemoteObjectType.ALBUM)
         for response in self.logger.get_progress_bar(iterable=responses, desc="Processing albums", unit="albums"):
             album = self.factory.album(response=response, skip_checks=True)
 
@@ -306,7 +301,7 @@ class RemoteLibrary[
         self.logger.debug(f"Load user's saved {self.api.source} artists: START")
         self.api.load_user_data()
 
-        responses = self.api.get_user_items(kind=RemoteObjectType.ARTIST, use_cache=self.use_cache)
+        responses = self.api.get_user_items(kind=RemoteObjectType.ARTIST)
         for response in self.logger.get_progress_bar(iterable=responses, desc="Processing artists", unit="artists"):
             artist = self.factory.artist(response=response, skip_checks=True)
 
@@ -380,7 +375,7 @@ class RemoteLibrary[
         uri_get = [uri for uri_list in playlists.values() for uri in uri_list if uri not in uri_tracks]
 
         if uri_get:
-            tracks_data = self.api.get_tracks(uri_get, features=False, use_cache=self.use_cache)
+            tracks_data = self.api.get_tracks(uri_get, features=False)
             tracks = list(map(self.factory.track, tracks_data))
             uri_tracks |= {track.uri: track for track in tracks}
 

--- a/musify/libraries/remote/core/library.py
+++ b/musify/libraries/remote/core/library.py
@@ -100,15 +100,9 @@ class RemoteLibrary[
 
     def extend(self, __items: Iterable[MusifyItem], allow_duplicates: bool = True) -> None:
         self.logger.debug(f"Extend {self.api.source} tracks data: START")
-        if not allow_duplicates:
-            self.logger.info(
-                "\33[1;95m ->\33[1;97m Extending library: "
-                "checking if the given items are already in this library \33[0m"
-            )
 
         load_uris = []
-        bar = self.logger.get_progress_bar(iterable=__items, desc="Checking items", unit="items")
-        for item in bar:
+        for item in __items:
             if not allow_duplicates and item in self.items:
                 continue
             elif isinstance(item, RemoteTrack):

--- a/musify/libraries/remote/core/object.py
+++ b/musify/libraries/remote/core/object.py
@@ -55,13 +55,7 @@ class RemoteCollectionLoader[T: RemoteObject](RemoteObject, RemoteCollection[T],
     @classmethod
     @abstractmethod
     def load(
-            cls,
-            value: str | Mapping[str, Any] | Self,
-            api: RemoteAPI,
-            use_cache: bool = True,
-            items: Iterable[T] = (),
-            *args,
-            **kwargs
+            cls, value: str | Mapping[str, Any] | Self, api: RemoteAPI, items: Iterable[T] = (), *args, **kwargs
     ) -> Self:
         """
         Generate a new object, calling all required endpoints to get a complete set of data for this item type.
@@ -77,8 +71,6 @@ class RemoteCollectionLoader[T: RemoteObject](RemoteObject, RemoteCollection[T],
 
         :param value: The value representing some remote collection. See description for allowed value types.
         :param api: An authorised API object to load the object from.
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         :param items: Optionally, give a list of available items to build a response for this collection.
             In doing so, the method will first try to find the API responses for the items of this collection
             in the given list before calling the API for any items not found there.
@@ -235,7 +227,7 @@ class RemotePlaylist[T: RemoteTrack](Playlist[T], RemoteCollectionLoader[T], met
         if not dry_run:
             added = self.api.add_to_playlist(self.url, items=uri_add, skip_dupes=kind != "refresh")
             if reload:  # reload the current playlist object from remote
-                self.reload(use_cache=False, extend_tracks=True)
+                self.reload(extend_tracks=True)
 
         return SyncResultRemotePlaylist(
             start=len(uri_remote),

--- a/musify/libraries/remote/core/object.py
+++ b/musify/libraries/remote/core/object.py
@@ -5,7 +5,7 @@ Implements core :py:class:`MusifyItem` and :py:class:`MusifyCollection` classes 
 """
 from __future__ import annotations
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
@@ -22,22 +22,25 @@ from musify.libraries.remote.core.exception import RemoteError
 from musify.utils import get_most_common_values
 
 
-class RemoteTrack(Track, RemoteItem, metaclass=ABCMeta):
+class RemoteTrack(Track, RemoteItem, ABC):
     """Extracts key ``track`` data from a remote API JSON response."""
 
+    __slots__ = ()
     __attributes_classes__ = (Track, RemoteItem)
 
 
-class RemoteCollection[T: RemoteObject](MusifyCollection[T], metaclass=ABCMeta):
+class RemoteCollection[T: RemoteObject](MusifyCollection[T], ABC):
     """Generic class for storing a collection of remote objects."""
 
+    __slots__ = ()
     __attributes_classes__ = MusifyCollection
     __attributes_ignore__ = ("items", "track_total")
 
 
-class RemoteCollectionLoader[T: RemoteObject](RemoteObject, RemoteCollection[T], metaclass=ABCMeta):
+class RemoteCollectionLoader[T: RemoteObject](RemoteObject, RemoteCollection[T], ABC):
     """Generic class for storing a collection of remote objects that can be loaded from an API response."""
 
+    __slots__ = ()
     __attributes_classes__ = (RemoteObject, RemoteCollection)
     __attributes_ignore__ = "_total"
 
@@ -110,9 +113,10 @@ class SyncResultRemotePlaylist(Result):
 PLAYLIST_SYNC_KINDS = Literal["new", "refresh", "sync"]
 
 
-class RemotePlaylist[T: RemoteTrack](Playlist[T], RemoteCollectionLoader[T], metaclass=ABCMeta):
+class RemotePlaylist[T: RemoteTrack](Playlist[T], RemoteCollectionLoader[T], ABC):
     """Extracts key ``playlist`` data from a remote API JSON response."""
 
+    __slots__ = ()
     __attributes_classes__ = (Playlist, RemoteCollectionLoader)
 
     @property
@@ -247,9 +251,10 @@ class RemotePlaylist[T: RemoteTrack](Playlist[T], RemoteCollectionLoader[T], met
         raise NotImplementedError
 
 
-class RemoteAlbum[T: RemoteTrack](Album[T], RemoteCollectionLoader[T], metaclass=ABCMeta):
+class RemoteAlbum[T: RemoteTrack](Album[T], RemoteCollectionLoader[T], ABC):
     """Extracts key ``album`` data from a remote API JSON response."""
 
+    __slots__ = ()
     __attributes_classes__ = (Album, RemoteCollectionLoader)
 
     @property
@@ -262,9 +267,10 @@ class RemoteAlbum[T: RemoteTrack](Album[T], RemoteCollectionLoader[T], metaclass
         raise NotImplementedError
 
 
-class RemoteArtist[T: (RemoteTrack, RemoteAlbum)](Artist[T], RemoteCollectionLoader[T], metaclass=ABCMeta):
+class RemoteArtist[T: (RemoteTrack, RemoteAlbum)](Artist[T], RemoteCollectionLoader[T], ABC):
     """Extracts key ``artist`` data from a remote API JSON response."""
 
+    __slots__ = ()
     __attributes_classes__ = (Artist, RemoteCollectionLoader)
 
     @property

--- a/musify/libraries/remote/core/processors/check.py
+++ b/musify/libraries/remote/core/processors/check.py
@@ -64,9 +64,11 @@ class RemoteItemChecker(InputProcessor):
     """
 
     __slots__ = (
+        "logger",
+        "matcher",
+        "factory",
         "interval",
         "allow_karaoke",
-        "factory",
         "_playlist_name_urls",
         "_playlist_name_collection",
         "_skip",
@@ -130,7 +132,7 @@ class RemoteItemChecker(InputProcessor):
 
     def _check_api(self):
         """Check if the API token has expired and refresh as necessary"""
-        if not self.api.handler.test_token():  # check if token has expired
+        if not self.api.handler.authoriser.test_token():  # check if token has expired
             self.logger.info_extra("\33[93mAPI token has expired, re-authorising... \33[0m")
             self.api.authorise()
 
@@ -349,7 +351,7 @@ class RemoteItemChecker(InputProcessor):
         source = self._playlist_name_collection[name]
         source_valid = [item for item in source if item.has_uri]
 
-        remote_response = self.api.get_items(self._playlist_name_urls[name], extend=True, use_cache=False)[0]
+        remote_response = self.api.get_items(self._playlist_name_urls[name], extend=True)[0]
         remote = self.factory.playlist(response=remote_response).items
         remote_valid = [item for item in remote if item.has_uri]
 

--- a/musify/libraries/remote/core/processors/search.py
+++ b/musify/libraries/remote/core/processors/search.py
@@ -104,8 +104,6 @@ class RemoteItemSearcher(Processor):
         return self.factory.api
 
     def __init__(self, matcher: ItemMatcher, object_factory: RemoteObjectFactory):
-        super().__init__()
-
         # noinspection PyTypeChecker
         #: The :py:class:`MusifyLogger` for this  object
         self.logger: MusifyLogger = logging.getLogger(__name__)

--- a/musify/libraries/remote/core/processors/search.py
+++ b/musify/libraries/remote/core/processors/search.py
@@ -71,11 +71,9 @@ class RemoteItemSearcher(Processor):
         during the checking operation
     :param object_factory: The :py:class:`RemoteObjectFactory` to use when creating new remote objects.
         This must have a :py:class:`RemoteAPI` assigned for this processor to work as expected.
-    :param use_cache: Use the cache when calling the API endpoint.
-        When using a CachedSession, set as False to refresh the cached response.
     """
 
-    __slots__ = ("factory", "use_cache")
+    __slots__ = ("logger", "matcher", "factory")
 
     #: The :py:class:`SearchSettings` for each :py:class:`RemoteObjectType`
     search_settings: dict[RemoteObjectType, SearchConfig] = {
@@ -105,7 +103,7 @@ class RemoteItemSearcher(Processor):
         """The :py:class:`RemoteAPI` to call"""
         return self.factory.api
 
-    def __init__(self, matcher: ItemMatcher, object_factory: RemoteObjectFactory, use_cache: bool = False):
+    def __init__(self, matcher: ItemMatcher, object_factory: RemoteObjectFactory):
         super().__init__()
 
         # noinspection PyTypeChecker
@@ -117,8 +115,6 @@ class RemoteItemSearcher(Processor):
         self.matcher = matcher
         #: The :py:class:`RemoteObjectFactory` to use when creating new remote objects.
         self.factory = object_factory
-        #: When true, use the cache when calling the API endpoint
-        self.use_cache = use_cache
 
     def _get_results(
             self, item: MusifyObject, kind: RemoteObjectType, settings: SearchConfig
@@ -297,7 +293,7 @@ class RemoteItemSearcher(Processor):
         responses = self._get_results(collection, kind=kind, settings=search_config)
         key = self.api.collection_item_map[kind]
         for response in responses:
-            self.api.extend_items(response, kind=kind, key=key, use_cache=self.use_cache)
+            self.api.extend_items(response, kind=kind, key=key)
 
         # noinspection PyProtectedMember,PyTypeChecker
         # order to prioritise results that are closer to the item count of the input collection
@@ -329,5 +325,4 @@ class RemoteItemSearcher(Processor):
         return {
             "matcher": self.matcher,
             "remote_source": self.factory.api.source,
-            "interval": self.use_cache,
         }

--- a/musify/libraries/remote/core/processors/wrangle.py
+++ b/musify/libraries/remote/core/processors/wrangle.py
@@ -14,6 +14,8 @@ from musify.libraries.remote.core.types import APIInputValue
 class RemoteDataWrangler(ABC):
     """Convert and validate remote ID and item types according to specific remote implementations."""
 
+    __slots__ = ()
+
     @property
     @abstractmethod
     def source(self) -> str:

--- a/musify/libraries/remote/core/processors/wrangle.py
+++ b/musify/libraries/remote/core/processors/wrangle.py
@@ -168,6 +168,8 @@ class RemoteDataWrangler(ABC):
         :return: Formatted string.
         :raise RemoteIDTypeError: Raised when the function cannot determine the item type
             of the input ``value``.
+        :raise RemoteObjectTypeError: Raised when the function cannot process the input ``value``
+            as a type of the given ``type_in`` i.e. the ``type_in`` does not match the actual type of the ``value``.
         """
         raise NotImplementedError
 

--- a/musify/libraries/remote/core/response.py
+++ b/musify/libraries/remote/core/response.py
@@ -2,14 +2,16 @@
 Just the core abstract class for the :py:mod:`Remote` module.
 Placed here separately to avoid circular import logic issues.
 """
-from abc import abstractmethod, ABCMeta
+from abc import ABC, abstractmethod
 from typing import Any
 
 from musify.core.base import MusifyObject
 from musify.libraries.remote.core.enum import RemoteObjectType
 
 
-class RemoteResponse(MusifyObject, metaclass=ABCMeta):
+class RemoteResponse(MusifyObject, ABC):
+
+    __slots__ = ()
 
     @property
     @abstractmethod

--- a/musify/libraries/remote/spotify/api/api.py
+++ b/musify/libraries/remote/spotify/api/api.py
@@ -75,6 +75,8 @@ class SpotifyAPI(SpotifyAPIMisc, SpotifyAPIItems, SpotifyAPIPlaylists):
     :param auth_kwargs: Optionally, provide kwargs to use when instantiating the :py:class:`APIAuthoriser`.
     """
 
+    __slots__ = ()
+
     @property
     def user_id(self) -> str | None:
         """ID of the currently authenticated user"""

--- a/musify/libraries/remote/spotify/api/api.py
+++ b/musify/libraries/remote/spotify/api/api.py
@@ -8,12 +8,15 @@ from collections.abc import Iterable
 from copy import deepcopy
 
 from musify import PROGRAM_NAME
+from musify.api.authorise import APIAuthoriser
+from musify.api.cache.backend.base import ResponseCache
 from musify.api.exception import APIError
+from musify.libraries.remote.spotify.api.cache import SpotifyRequestSettings, SpotifyPaginatedRequestSettings
 from musify.libraries.remote.spotify.api.item import SpotifyAPIItems
 from musify.libraries.remote.spotify.api.misc import SpotifyAPIMisc
 from musify.libraries.remote.spotify.api.playlist import SpotifyAPIPlaylists
 from musify.libraries.remote.spotify.processors import SpotifyDataWrangler
-from musify.utils import safe_format_map
+from musify.utils import safe_format_map, merge_maps
 
 URL_AUTH = "https://accounts.spotify.com"
 
@@ -68,6 +71,8 @@ class SpotifyAPI(SpotifyAPIMisc, SpotifyAPIItems, SpotifyAPIPlaylists):
     :param client_id: The client ID to use when authorising requests.
     :param client_secret: The client secret to use when authorising requests.
     :param scopes: The scopes to request access to.
+    :param cache: When given, attempt to use this cache for certain request types before calling the API.
+    :param auth_kwargs: Optionally, provide kwargs to use when instantiating the :py:class:`APIAuthoriser`.
     """
 
     @property
@@ -95,16 +100,30 @@ class SpotifyAPI(SpotifyAPIMisc, SpotifyAPIItems, SpotifyAPIPlaylists):
             client_id: str | None = None,
             client_secret: str | None = None,
             scopes: Iterable[str] = (),
-            **kwargs,
+            cache: ResponseCache | None = None,
+            **auth_kwargs
     ):
         wrangler = SpotifyDataWrangler()
+
         format_map = {
             "client_id": client_id,
             "client_base64": base64.b64encode(f"{client_id}:{client_secret}".encode()).decode(),
             "scopes": " ".join(scopes),
             "url": wrangler.url_api
         }
-        auth_kwargs = deepcopy(SPOTIFY_API_AUTH_ARGS)
+        auth_kwargs = merge_maps(deepcopy(SPOTIFY_API_AUTH_ARGS), auth_kwargs)
         safe_format_map(auth_kwargs, format_map=format_map)
 
-        super().__init__(wrangler=wrangler, **auth_kwargs, **kwargs)
+        auth_kwargs.pop("name", None)
+        authoriser = APIAuthoriser(name=wrangler.source, **auth_kwargs)
+
+        if cache is not None:
+            cache.create_storage(SpotifyRequestSettings(name="tracks"))
+            cache.create_storage(SpotifyRequestSettings(name="artists"))
+            cache.create_storage(SpotifyRequestSettings(name="albums"))
+            cache.create_storage(SpotifyRequestSettings(name="playlists"))
+            cache.create_storage(SpotifyPaginatedRequestSettings(name="artist_albums"))
+            cache.create_storage(SpotifyPaginatedRequestSettings(name="album_tracks"))
+            cache.create_storage(SpotifyPaginatedRequestSettings(name="playlist_tracks"))
+
+        super().__init__(authoriser=authoriser, wrangler=wrangler, cache=cache)

--- a/musify/libraries/remote/spotify/api/api.py
+++ b/musify/libraries/remote/spotify/api/api.py
@@ -129,12 +129,22 @@ class SpotifyAPI(SpotifyAPIMisc, SpotifyAPIItems, SpotifyAPIPlaylists):
         cache.repository_getter = self._get_cache_repository
 
         cache.create_repository(SpotifyRequestSettings(name="tracks"))
-        cache.create_repository(SpotifyRequestSettings(name="artists"))
-        cache.create_repository(SpotifyRequestSettings(name="albums"))
         cache.create_repository(SpotifyRequestSettings(name="audio_features"))
         cache.create_repository(SpotifyRequestSettings(name="audio_analysis"))
+
+        cache.create_repository(SpotifyRequestSettings(name="albums"))
         cache.create_repository(SpotifyPaginatedRequestSettings(name="album_tracks"))
+
+        cache.create_repository(SpotifyRequestSettings(name="artists"))
         cache.create_repository(SpotifyPaginatedRequestSettings(name="artist_albums"))
+
+        cache.create_repository(SpotifyRequestSettings(name="shows"))
+        cache.create_repository(SpotifyRequestSettings(name="episodes"))
+        cache.create_repository(SpotifyPaginatedRequestSettings(name="show_episodes"))
+
+        cache.create_repository(SpotifyRequestSettings(name="audiobooks"))
+        cache.create_repository(SpotifyRequestSettings(name="chapters"))
+        cache.create_repository(SpotifyPaginatedRequestSettings(name="audiobook_chapters"))
 
     @staticmethod
     def _get_cache_repository(cache: ResponseCache, url: str) -> ResponseRepository | None:

--- a/musify/libraries/remote/spotify/api/api.py
+++ b/musify/libraries/remote/spotify/api/api.py
@@ -119,7 +119,7 @@ class SpotifyAPI(SpotifyAPIMisc, SpotifyAPIItems, SpotifyAPIPlaylists):
         auth_kwargs.pop("name", None)
         authoriser = APIAuthoriser(name=wrangler.source, **auth_kwargs)
 
-        if cache is not None:
+        if cache is not None:  # TODO: implement and set storage getter function on cache
             cache.create_storage(SpotifyRequestSettings(name="tracks"))
             cache.create_storage(SpotifyRequestSettings(name="artists"))
             cache.create_storage(SpotifyRequestSettings(name="albums"))

--- a/musify/libraries/remote/spotify/api/api.py
+++ b/musify/libraries/remote/spotify/api/api.py
@@ -128,13 +128,11 @@ class SpotifyAPI(SpotifyAPIMisc, SpotifyAPIItems, SpotifyAPIPlaylists):
 
         cache.repository_getter = self._get_cache_repository
 
-        cache.create_repository(SpotifyRequestSettings(name="playlists"))
         cache.create_repository(SpotifyRequestSettings(name="tracks"))
         cache.create_repository(SpotifyRequestSettings(name="artists"))
         cache.create_repository(SpotifyRequestSettings(name="albums"))
         cache.create_repository(SpotifyRequestSettings(name="audio_features"))
         cache.create_repository(SpotifyRequestSettings(name="audio_analysis"))
-        cache.create_repository(SpotifyPaginatedRequestSettings(name="playlist_tracks"))
         cache.create_repository(SpotifyPaginatedRequestSettings(name="album_tracks"))
         cache.create_repository(SpotifyPaginatedRequestSettings(name="artist_albums"))
 

--- a/musify/libraries/remote/spotify/api/api.py
+++ b/musify/libraries/remote/spotify/api/api.py
@@ -119,13 +119,13 @@ class SpotifyAPI(SpotifyAPIMisc, SpotifyAPIItems, SpotifyAPIPlaylists):
         auth_kwargs.pop("name", None)
         authoriser = APIAuthoriser(name=wrangler.source, **auth_kwargs)
 
-        if cache is not None:  # TODO: implement and set storage getter function on cache
-            cache.create_storage(SpotifyRequestSettings(name="tracks"))
-            cache.create_storage(SpotifyRequestSettings(name="artists"))
-            cache.create_storage(SpotifyRequestSettings(name="albums"))
-            cache.create_storage(SpotifyRequestSettings(name="playlists"))
-            cache.create_storage(SpotifyPaginatedRequestSettings(name="artist_albums"))
-            cache.create_storage(SpotifyPaginatedRequestSettings(name="album_tracks"))
-            cache.create_storage(SpotifyPaginatedRequestSettings(name="playlist_tracks"))
+        if cache is not None:  # TODO: implement and set repository_getter function on cache
+            cache.create_repository(SpotifyRequestSettings(name="tracks"))
+            cache.create_repository(SpotifyRequestSettings(name="artists"))
+            cache.create_repository(SpotifyRequestSettings(name="albums"))
+            cache.create_repository(SpotifyRequestSettings(name="playlists"))
+            cache.create_repository(SpotifyPaginatedRequestSettings(name="artist_albums"))
+            cache.create_repository(SpotifyPaginatedRequestSettings(name="album_tracks"))
+            cache.create_repository(SpotifyPaginatedRequestSettings(name="playlist_tracks"))
 
         super().__init__(authoriser=authoriser, wrangler=wrangler, cache=cache)

--- a/musify/libraries/remote/spotify/api/base.py
+++ b/musify/libraries/remote/spotify/api/base.py
@@ -1,15 +1,17 @@
 """
 Base functionality to be shared by all classes that implement :py:class:`RemoteAPI` functionality for Spotify.
 """
-from abc import ABCMeta
+from abc import ABC
 from typing import Any
 from urllib.parse import parse_qs, urlparse, urlencode, quote, urlunparse
 
 from musify.libraries.remote.core.api import RemoteAPI
 
 
-class SpotifyAPIBase(RemoteAPI, metaclass=ABCMeta):
+class SpotifyAPIBase(RemoteAPI, ABC):
     """Base functionality required for all endpoint functions for the Spotify API"""
+
+    __slots__ = ()
 
     #: The key to reference when extracting items from a collection
     items_key = "items"

--- a/musify/libraries/remote/spotify/api/base.py
+++ b/musify/libraries/remote/spotify/api/base.py
@@ -6,6 +6,7 @@ from typing import Any
 from urllib.parse import parse_qs, urlparse, urlencode, quote, urlunparse
 
 from musify.libraries.remote.core.api import RemoteAPI
+from musify.libraries.remote.core.enum import RemoteObjectType
 
 
 class SpotifyAPIBase(RemoteAPI, ABC):
@@ -15,6 +16,14 @@ class SpotifyAPIBase(RemoteAPI, ABC):
 
     #: The key to reference when extracting items from a collection
     items_key = "items"
+
+    @staticmethod
+    def _get_key(key: str | RemoteObjectType | None) -> str | None:
+        if key is None:
+            return
+        if isinstance(key, RemoteObjectType):
+            key = key.name
+        return key.lower().rstrip("s") + "s"
 
     @staticmethod
     def format_next_url(url: str, offset: int = 0, limit: int = 20) -> str:

--- a/musify/libraries/remote/spotify/api/cache.py
+++ b/musify/libraries/remote/spotify/api/cache.py
@@ -1,0 +1,24 @@
+from urllib.parse import urlparse, parse_qs
+
+from musify.api.cache.backend.base import RequestSettings, PaginatedRequestSettings
+from musify.libraries.remote.core.enum import RemoteIDType
+from musify.libraries.remote.spotify.processors import SpotifyDataWrangler
+
+
+class SpotifyRequestSettings(RequestSettings):
+
+    wrangler = SpotifyDataWrangler()
+
+    def get_id(self, url: str) -> str:
+        return self.wrangler.convert(url, type_in=RemoteIDType.URL, type_out=RemoteIDType.ID)
+
+
+class SpotifyPaginatedRequestSettings(PaginatedRequestSettings, SpotifyRequestSettings):
+
+    def get_offset(self, url: str) -> int:
+        params = parse_qs(urlparse(url).query)
+        return int(params.get("offset", [0])[0])
+
+    def get_limit(self, url: str) -> int:
+        params = parse_qs(urlparse(url).query)
+        return int(params.get("limit", [50])[0])

--- a/musify/libraries/remote/spotify/api/cache.py
+++ b/musify/libraries/remote/spotify/api/cache.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse, parse_qs
 
 from musify.api.cache.backend.base import RequestSettings, PaginatedRequestSettings
+from musify.api.exception import CacheError
 from musify.libraries.remote.core.enum import RemoteIDType
 from musify.libraries.remote.spotify.processors import SpotifyDataWrangler
 
@@ -10,6 +11,8 @@ class SpotifyRequestSettings(RequestSettings):
     wrangler = SpotifyDataWrangler()
 
     def get_id(self, url: str) -> str:
+        if "/me" in url.rstrip("/"):
+            raise CacheError("Cannot get IDs for 'me' endpoints")
         return self.wrangler.convert(url, type_in=RemoteIDType.URL, type_out=RemoteIDType.ID)
 
 

--- a/musify/libraries/remote/spotify/api/item.py
+++ b/musify/libraries/remote/spotify/api/item.py
@@ -45,7 +45,7 @@ class SpotifyAPIItems(SpotifyAPIBase, ABC):
             self.logger.debug(f"{'CACHE':<7}: {url:<43} | No cache configured, skipping...")
             return [], id_list
 
-        repository = self.handler.cache.get_repository_for_url(url=url)
+        repository = self.handler.cache.get_repository_from_url(url=url)
         results = repository.get_responses([(id_,) for id_ in id_list])
 
         id_list_found = {result["id"] for result in results}

--- a/musify/libraries/remote/spotify/api/item.py
+++ b/musify/libraries/remote/spotify/api/item.py
@@ -14,7 +14,7 @@ from musify.libraries.remote.core.enum import RemoteIDType, RemoteObjectType
 from musify.libraries.remote.core.exception import RemoteObjectTypeError
 from musify.libraries.remote.core.types import APIInputValue
 from musify.libraries.remote.spotify.api.base import SpotifyAPIBase
-from musify.utils import limit_value
+from musify.utils import limit_value, to_collection
 
 ARTIST_ALBUM_TYPES = {"album", "single", "compilation", "appears_on"}
 
@@ -32,7 +32,7 @@ class SpotifyAPIItems(SpotifyAPIBase, metaclass=ABCMeta):
     ###########################################################################
     ## GET helpers: Generic methods for getting items
     ###########################################################################
-    def _get_items_from_cache(self, url: str, id_list: list[str]) -> tuple[list[dict[str, Any]], list[str]]:
+    def _get_items_from_cache(self, url: str, id_list: Collection[str]) -> tuple[list[dict[str, Any]], Collection[str]]:
         """
         Attempt to find the given ``id_list`` in the cache of the request handler and return results.
 
@@ -58,7 +58,7 @@ class SpotifyAPIItems(SpotifyAPIBase, metaclass=ABCMeta):
     def _get_items_multi(
             self,
             url: str,
-            id_list: list[str],
+            id_list: Collection[str],
             params: Mapping[str, Any] | None = None,
             key: str | None = None,
             kind: str | None = None,
@@ -101,13 +101,14 @@ class SpotifyAPIItems(SpotifyAPIBase, metaclass=ABCMeta):
             results.extend(response[key]) if key else results.append(response)
 
         if len(id_list_reduced) != len(id_list):  # cache was used, sort the results to same order as input IDs
+            id_list = to_collection(id_list)
             results.sort(key=lambda result: id_list.index(result["id"]))
         return results
 
     def _get_items_batched(
             self,
             url: str,
-            id_list: list[str],
+            id_list: Collection[str],
             params: Mapping[str, Any] | None = None,
             key: str | None = None,
             kind: str | None = None,
@@ -157,6 +158,7 @@ class SpotifyAPIItems(SpotifyAPIBase, metaclass=ABCMeta):
             results.extend(response[key]) if key else results.append(response)
 
         if len(id_list_reduced) != len(id_list):  # cache was used, sort the results to same order as input IDs
+            id_list = to_collection(id_list)
             results.sort(key=lambda result: id_list.index(result["id"]))
         return results
 

--- a/musify/libraries/remote/spotify/api/item.py
+++ b/musify/libraries/remote/spotify/api/item.py
@@ -2,7 +2,7 @@
 Implements endpoints for getting items from the Spotify API.
 """
 import re
-from abc import ABCMeta
+from abc import ABC
 from collections.abc import Collection, Mapping, MutableMapping
 from itertools import batched
 from typing import Any
@@ -19,7 +19,9 @@ from musify.utils import limit_value, to_collection
 ARTIST_ALBUM_TYPES = {"album", "single", "compilation", "appears_on"}
 
 
-class SpotifyAPIItems(SpotifyAPIBase, metaclass=ABCMeta):
+class SpotifyAPIItems(SpotifyAPIBase, ABC):
+
+    __slots__ = ()
 
     _bar_threshold = 5
 

--- a/musify/libraries/remote/spotify/api/item.py
+++ b/musify/libraries/remote/spotify/api/item.py
@@ -45,8 +45,8 @@ class SpotifyAPIItems(SpotifyAPIBase, ABC):
             self.logger.debug(f"{'CACHE':<7}: {url:<43} | No cache configured, skipping...")
             return [], id_list
 
-        storage = self.handler.cache.get_storage_for_url(url=url)
-        results = storage.get_responses([(id_,) for id_ in id_list])
+        repository = self.handler.cache.get_repository_for_url(url=url)
+        results = repository.get_responses([(id_,) for id_ in id_list])
 
         id_list_found = {result["id"] for result in results}
         id_list_not_found = [id_ for id_ in id_list if id_ not in id_list_found]

--- a/musify/libraries/remote/spotify/api/misc.py
+++ b/musify/libraries/remote/spotify/api/misc.py
@@ -18,7 +18,6 @@ class SpotifyAPIMisc(SpotifyAPIBase, metaclass=ABCMeta):
             value: str | MutableMapping[str, Any] | None = None,
             kind: RemoteIDType | None = None,
             limit: int = 20,
-            use_cache: bool = True
     ) -> None:
         if not value:  # get user to paste in URL/URI
             value = input("\33[1mEnter URL/URI/ID: \33[0m")
@@ -54,7 +53,7 @@ class SpotifyAPIMisc(SpotifyAPIBase, metaclass=ABCMeta):
                 self.print_item(i=i, name=track["name"], uri=track["uri"], length=length, total=response["total"])
 
             if response["next"]:
-                response = self.handler.get(response["next"], params={"limit": limit}, use_cache=use_cache)
+                response = self.handler.get(response["next"], params={"limit": limit})
             print()
 
     ###########################################################################
@@ -66,22 +65,18 @@ class SpotifyAPIMisc(SpotifyAPIBase, metaclass=ABCMeta):
 
         :param update_user_data: When True, update the ``_user_data`` stored in this API object.
         """
-        r = self.handler.get(url=f"{self.url}/me", use_cache=True, log_pad=71)
+        r = self.handler.get(url=f"{self.url}/me", log_pad=71)
         if update_user_data:
             self.user_data = r
         return r
 
-    def query(
-            self, query: str | None, kind: RemoteObjectType, limit: int = 10, use_cache: bool = True
-    ) -> list[dict[str, Any]]:
+    def query(self, query: str | None, kind: RemoteObjectType, limit: int = 10) -> list[dict[str, Any]]:
         """
         ``GET: /search`` - Query for items. Modify result types returned with kind parameter
 
         :param query: Search query.
         :param kind: The remote object type to search for.
         :param limit: Number of results to get and return.
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         :return: The response from the endpoint.
         """
         if not query or len(query) > 150:  # query is too short or too long, skip
@@ -89,7 +84,7 @@ class SpotifyAPIMisc(SpotifyAPIBase, metaclass=ABCMeta):
 
         url = f"{self.url}/search"
         params = {'q': query, "type": kind.name.lower(), "limit": limit_value(limit, floor=1, ceil=50)}
-        response = self.handler.get(url, params=params, use_cache=use_cache)
+        response = self.handler.get(url, params=params)
 
         if "error" in response:
             self.logger.error(f"{'ERROR':<7}: {url:<43} | Query: {query} | {response['error']}")

--- a/musify/libraries/remote/spotify/api/misc.py
+++ b/musify/libraries/remote/spotify/api/misc.py
@@ -1,7 +1,7 @@
 """
 Implements all required non-items and non-playlist endpoints from the Spotify API.
 """
-from abc import ABCMeta
+from abc import ABC
 from collections.abc import MutableMapping
 from typing import Any
 
@@ -11,7 +11,9 @@ from musify.types import Number
 from musify.utils import limit_value
 
 
-class SpotifyAPIMisc(SpotifyAPIBase, metaclass=ABCMeta):
+class SpotifyAPIMisc(SpotifyAPIBase, ABC):
+
+    __slots__ = ()
 
     def print_collection(
             self,

--- a/musify/libraries/remote/spotify/api/misc.py
+++ b/musify/libraries/remote/spotify/api/misc.py
@@ -92,7 +92,7 @@ class SpotifyAPIMisc(SpotifyAPIBase, ABC):
             self.logger.error(f"{'ERROR':<7}: {url:<43} | Query: {query} | {response['error']}")
             return []
 
-        results = response[f"{kind.name.lower()}s"]["items"]
+        results = response[f"{kind.name.lower()}s"][self.items_key]
         if kind not in self.collection_item_map:
             return results
 

--- a/musify/libraries/remote/spotify/api/playlist.py
+++ b/musify/libraries/remote/spotify/api/playlist.py
@@ -17,7 +17,7 @@ from musify.utils import limit_value
 class SpotifyAPIPlaylists(SpotifyAPIBase, metaclass=ABCMeta):
     """API endpoints for processing collections i.e. playlists, albums, shows, and audiobooks"""
 
-    def get_playlist_url(self, playlist: str | Mapping[str, Any] | RemoteResponse, use_cache: bool = True) -> str:
+    def get_playlist_url(self, playlist: str | Mapping[str, Any] | RemoteResponse) -> str:
         """
         Determine the type of the given ``playlist`` and return its API URL.
         If type cannot be determined, attempt to find the playlist in the
@@ -28,8 +28,6 @@ class SpotifyAPIPlaylists(SpotifyAPIBase, metaclass=ABCMeta):
             - the name of the playlist in the current user's playlists,
             - the API response of a playlist.
             - a RemoteResponse object representing a remote playlist.
-        :param use_cache: When a CachedSession is available, use the cache when calling the API endpoint.
-            Set as False to refresh the cached response of the CachedSession.
         :return: The playlist URL.
         :raise RemoteIDTypeError: Raised when the function cannot determine the item type of
             the input ``playlist``. Or when it does not recognise the type of the input ``playlist`` parameter.
@@ -52,7 +50,7 @@ class SpotifyAPIPlaylists(SpotifyAPIBase, metaclass=ABCMeta):
         try:
             return self.wrangler.convert(playlist, kind=RemoteObjectType.PLAYLIST, type_out=RemoteIDType.URL)
         except RemoteIDTypeError:
-            playlists = self.get_user_items(kind=RemoteObjectType.PLAYLIST, use_cache=use_cache)
+            playlists = self.get_user_items(kind=RemoteObjectType.PLAYLIST)
             playlists = {pl["name"]: pl["href"] for pl in playlists}
             if playlist not in playlists:
                 raise RemoteIDTypeError(
@@ -110,7 +108,7 @@ class SpotifyAPIPlaylists(SpotifyAPIBase, metaclass=ABCMeta):
         :raise RemoteObjectTypeError: Raised when the item types of the input ``items``
             are not all tracks or IDs.
         """
-        url = f"{self.get_playlist_url(playlist, use_cache=False)}/tracks"
+        url = f"{self.get_playlist_url(playlist)}/tracks"
 
         if len(items) == 0:
             self.logger.debug(f"{'SKIP':<7}: {url:<43} | No data given")
@@ -122,7 +120,7 @@ class SpotifyAPIPlaylists(SpotifyAPIBase, metaclass=ABCMeta):
             self.wrangler.convert(item, kind=RemoteObjectType.TRACK, type_out=RemoteIDType.URI) for item in items
         ]
         if skip_dupes:  # skip tracks currently in playlist
-            pl_current = self.get_items(url, kind=RemoteObjectType.PLAYLIST, use_cache=False)[0]
+            pl_current = self.get_items(url, kind=RemoteObjectType.PLAYLIST)[0]
             tracks_key = self.collection_item_map[RemoteObjectType.PLAYLIST].name.lower() + "s"
             tracks = pl_current[tracks_key][self.items_key]
 
@@ -152,7 +150,7 @@ class SpotifyAPIPlaylists(SpotifyAPIBase, metaclass=ABCMeta):
             - a RemoteResponse object representing a remote playlist.
         :return: API URL for playlist.
         """
-        url = f"{self.get_playlist_url(playlist, use_cache=False)}/followers"
+        url = f"{self.get_playlist_url(playlist)}/followers"
         self.handler.delete(url, log_pad=43)
         return url
 
@@ -180,13 +178,13 @@ class SpotifyAPIPlaylists(SpotifyAPIBase, metaclass=ABCMeta):
         :raise RemoteObjectTypeError: Raised when the item types of the input ``items``
             are not all tracks or IDs.
         """
-        url = f"{self.get_playlist_url(playlist, use_cache=False)}/tracks"
+        url = f"{self.get_playlist_url(playlist)}/tracks"
         if items is not None and len(items) == 0:
             self.logger.debug(f"{'SKIP':<7}: {url:<43} | No data given")
             return 0
 
         if items is None:  # clear everything
-            pl_current = self.get_items(url, kind=RemoteObjectType.PLAYLIST, extend=True, use_cache=False)[0]
+            pl_current = self.get_items(url, kind=RemoteObjectType.PLAYLIST, extend=True)[0]
 
             tracks_key = self.collection_item_map[RemoteObjectType.PLAYLIST].name.lower() + "s"
             tracks = pl_current[tracks_key][self.items_key]

--- a/musify/libraries/remote/spotify/api/playlist.py
+++ b/musify/libraries/remote/spotify/api/playlist.py
@@ -42,11 +42,17 @@ class SpotifyAPIPlaylists(SpotifyAPIBase, ABC):
                 return playlist["href"]
             elif self.id_key in playlist:
                 return self.wrangler.convert(
-                    playlist[self.id_key], kind=RemoteObjectType.PLAYLIST, type_in=RemoteIDType.ID, type_out=RemoteIDType.URL
+                    playlist[self.id_key],
+                    kind=RemoteObjectType.PLAYLIST,
+                    type_in=RemoteIDType.ID,
+                    type_out=RemoteIDType.URL
                 )
             elif "uri" in playlist:
                 return self.wrangler.convert(
-                    playlist["uri"], kind=RemoteObjectType.PLAYLIST, type_in=RemoteIDType.URI, type_out=RemoteIDType.URL
+                    playlist["uri"],
+                    kind=RemoteObjectType.PLAYLIST,
+                    type_in=RemoteIDType.URI,
+                    type_out=RemoteIDType.URL
                 )
 
         try:

--- a/musify/libraries/remote/spotify/api/playlist.py
+++ b/musify/libraries/remote/spotify/api/playlist.py
@@ -40,9 +40,9 @@ class SpotifyAPIPlaylists(SpotifyAPIBase, ABC):
         if isinstance(playlist, Mapping):
             if "href" in playlist:
                 return playlist["href"]
-            elif "id" in playlist:
+            elif self.id_key in playlist:
                 return self.wrangler.convert(
-                    playlist["id"], kind=RemoteObjectType.PLAYLIST, type_in=RemoteIDType.ID, type_out=RemoteIDType.URL
+                    playlist[self.id_key], kind=RemoteObjectType.PLAYLIST, type_in=RemoteIDType.ID, type_out=RemoteIDType.URL
                 )
             elif "uri" in playlist:
                 return self.wrangler.convert(

--- a/musify/libraries/remote/spotify/api/playlist.py
+++ b/musify/libraries/remote/spotify/api/playlist.py
@@ -1,7 +1,7 @@
 """
 Implements endpoints for manipulating playlists with the Spotify API.
 """
-from abc import ABCMeta
+from abc import ABC
 from collections.abc import Collection, Mapping
 from itertools import batched
 from typing import Any
@@ -14,8 +14,10 @@ from musify.libraries.remote.spotify.api.base import SpotifyAPIBase
 from musify.utils import limit_value
 
 
-class SpotifyAPIPlaylists(SpotifyAPIBase, metaclass=ABCMeta):
+class SpotifyAPIPlaylists(SpotifyAPIBase, ABC):
     """API endpoints for processing collections i.e. playlists, albums, shows, and audiobooks"""
+
+    __slots__ = ()
 
     def get_playlist_url(self, playlist: str | Mapping[str, Any] | RemoteResponse) -> str:
         """

--- a/musify/libraries/remote/spotify/base.py
+++ b/musify/libraries/remote/spotify/base.py
@@ -3,8 +3,7 @@ Core abstract classes for the :py:mod:`Spotify` module.
 
 These define the foundations of any Spotify object or item.
 """
-from abc import ABCMeta
-from typing import Any
+from abc import ABC
 
 from musify.libraries.remote.core.base import RemoteObject, RemoteItem
 from musify.libraries.remote.core.enum import RemoteObjectType
@@ -12,8 +11,10 @@ from musify.libraries.remote.core.exception import RemoteObjectTypeError, Remote
 from musify.libraries.remote.spotify.api import SpotifyAPI
 
 
-class SpotifyObject(RemoteObject[SpotifyAPI], metaclass=ABCMeta):
+class SpotifyObject(RemoteObject[SpotifyAPI], ABC):
     """Generic base class for Spotify-stored objects. Extracts key data from a Spotify API JSON response."""
+
+    __slots__ = ()
 
     _url_pad = 71
 
@@ -37,9 +38,6 @@ class SpotifyObject(RemoteObject[SpotifyAPI], metaclass=ABCMeta):
     def url_ext(self):
         return self.response["external_urls"].get("spotify")
 
-    def __init__(self, response: dict[str, Any], api: SpotifyAPI | None = None, skip_checks: bool = False):
-        super().__init__(response=response, api=api, skip_checks=skip_checks)
-
     def _check_type(self) -> None:
         """
         Checks the given response is compatible with this object type, raises an exception if not.
@@ -57,6 +55,7 @@ class SpotifyObject(RemoteObject[SpotifyAPI], metaclass=ABCMeta):
             raise RemoteObjectTypeError("Response type invalid", kind=kind, value=self.response.get("type"))
 
 
-class SpotifyItem(SpotifyObject, RemoteItem, metaclass=ABCMeta):
+class SpotifyItem(SpotifyObject, RemoteItem, ABC):
     """Generic base class for Spotify-stored items. Extracts key data from a Spotify API JSON response."""
-    pass
+
+    __slots__ = ()

--- a/musify/libraries/remote/spotify/library.py
+++ b/musify/libraries/remote/spotify/library.py
@@ -63,14 +63,12 @@ class SpotifyLibrary(RemoteLibrary[SpotifyAPI, SpotifyPlaylist, SpotifyTrack, Sp
         )
 
         tracks = [track for track in self.tracks if track.has_uri]
-        self.api.extend_tracks(tracks, features=features, analysis=analysis, use_cache=self.use_cache)
+        self.api.extend_tracks(tracks, features=features, analysis=analysis)
 
         # enrich on list of URIs to avoid duplicate calls for same items
         if albums:
             album_uris: set[str] = {track.response["album"]["uri"] for track in self.tracks}
-            album_responses = self.api.get_items(
-                album_uris, kind=RemoteObjectType.ALBUM, extend=False, use_cache=self.use_cache
-            )
+            album_responses = self.api.get_items(album_uris, kind=RemoteObjectType.ALBUM, extend=False)
             for album in album_responses:
                 album.pop("tracks")
 
@@ -80,9 +78,7 @@ class SpotifyLibrary(RemoteLibrary[SpotifyAPI, SpotifyPlaylist, SpotifyTrack, Sp
 
         if artists:
             artist_uris: set[str] = {artist["uri"] for track in self.tracks for artist in track.response["artists"]}
-            artist_responses = self.api.get_items(
-                artist_uris, kind=RemoteObjectType.ARTIST, extend=False, use_cache=self.use_cache
-            )
+            artist_responses = self.api.get_items(artist_uris, kind=RemoteObjectType.ARTIST, extend=False)
 
             artists = {response["uri"]: response for response in artist_responses}
             for track in self.tracks:
@@ -106,7 +102,7 @@ class SpotifyLibrary(RemoteLibrary[SpotifyAPI, SpotifyPlaylist, SpotifyTrack, Sp
         key = self.api.collection_item_map[kind]
 
         for album in self.albums:
-            self.api.extend_items(album, kind=kind, key=key, use_cache=self.use_cache)
+            self.api.extend_items(album, kind=kind, key=key)
             album.refresh(skip_checks=False)
 
             for track in album.tracks:  # add tracks from this album to the user's saved tracks
@@ -130,7 +126,7 @@ class SpotifyLibrary(RemoteLibrary[SpotifyAPI, SpotifyPlaylist, SpotifyTrack, Sp
             f"\33[1;95m  >\33[1;97m Enriching {len(self.artists)} {self.api.source} artists \33[0m"
         )
 
-        self.api.get_artist_albums(self.artists, types=types, use_cache=self.use_cache)
+        self.api.get_artist_albums(self.artists, types=types)
 
         if tracks:
             kind = RemoteObjectType.ALBUM
@@ -139,7 +135,7 @@ class SpotifyLibrary(RemoteLibrary[SpotifyAPI, SpotifyPlaylist, SpotifyTrack, Sp
             responses_albums = [album for artist in self.artists for album in artist.albums]
             bar = self.logger.get_progress_bar(iterable=responses_albums, desc="Getting album tracks", unit="albums")
             for album in bar:
-                self.api.extend_items(album, kind=kind, key=key, use_cache=self.use_cache)
+                self.api.extend_items(album, kind=kind, key=key)
                 album.refresh(skip_checks=False)
 
         self.logger.debug(f"Enrich {self.api.source} artists: DONE\n")

--- a/musify/libraries/remote/spotify/library.py
+++ b/musify/libraries/remote/spotify/library.py
@@ -16,6 +16,8 @@ class SpotifyLibrary(RemoteLibrary[SpotifyAPI, SpotifyPlaylist, SpotifyTrack, Sp
     Represents a Spotify library. Provides various methods for manipulating
     tracks and playlists across an entire Spotify library collection.
     """
+
+    __slots__ = ()
     __attributes_classes__ = RemoteLibrary
 
     @staticmethod

--- a/musify/libraries/remote/spotify/object.py
+++ b/musify/libraries/remote/spotify/object.py
@@ -3,7 +3,7 @@ Implements all :py:mod:`Remote` object types for Spotify.
 """
 from __future__ import annotations
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Iterable, MutableMapping, Mapping, Collection
 from copy import copy, deepcopy
 from datetime import datetime
@@ -251,8 +251,10 @@ class SpotifyTrack(SpotifyItem, RemoteTrack):
         self.__init__(response=response, api=self.api)
 
 
-class SpotifyCollectionLoader[T: SpotifyObject](RemoteCollectionLoader[T], SpotifyObject, metaclass=ABCMeta):
+class SpotifyCollectionLoader[T: SpotifyObject](RemoteCollectionLoader[T], SpotifyObject, ABC):
     """Generic class for storing a collection of Spotify objects that can be loaded from an API response."""
+
+    __slots__ = ()
 
     @classmethod
     def _get_item_kind(cls, api: SpotifyAPI) -> RemoteObjectType:

--- a/musify/libraries/remote/spotify/processors.py
+++ b/musify/libraries/remote/spotify/processors.py
@@ -18,6 +18,8 @@ from musify.utils import to_collection
 
 class SpotifyDataWrangler(RemoteDataWrangler):
 
+    __slots__ = ()
+
     source = SOURCE_NAME
     unavailable_uri_dummy = "spotify:track:unavailable"
     url_api = "https://api.spotify.com/v1"

--- a/musify/log/filter.py
+++ b/musify/log/filter.py
@@ -61,7 +61,12 @@ def format_full_func_name(record: logging.LogRecord, width: int = 40) -> None:
 
 
 class LogConsoleFilter(logging.Filter):
-    """Filter for logging to the console."""
+    """
+    Filter for logging to the console.
+
+    :param module_width: The maximum width a module string can be in the log record.
+        Truncates module string if longer that this length.
+    """
 
     __slots__ = ("module_width",)
 
@@ -76,7 +81,12 @@ class LogConsoleFilter(logging.Filter):
 
 
 class LogFileFilter(logging.Filter):
-    """Filter for logging to a file."""
+    """
+    Filter for logging to a file.
+
+    :param module_width: The maximum width a module string can be in the log record.
+        Truncates module string if longer that this length.
+    """
 
     __slots__ = ("module_width",)
 

--- a/musify/log/filter.py
+++ b/musify/log/filter.py
@@ -63,6 +63,8 @@ def format_full_func_name(record: logging.LogRecord, width: int = 40) -> None:
 class LogConsoleFilter(logging.Filter):
     """Filter for logging to the console."""
 
+    __slots__ = ("module_width",)
+
     def __init__(self, name: str = "", module_width: int = 40):
         super().__init__(name)
         self.module_width = module_width
@@ -75,6 +77,8 @@ class LogConsoleFilter(logging.Filter):
 
 class LogFileFilter(logging.Filter):
     """Filter for logging to a file."""
+
+    __slots__ = ("module_width",)
 
     def __init__(self, name: str = "", module_width: int = 40):
         super().__init__(name)

--- a/musify/log/handlers.py
+++ b/musify/log/handlers.py
@@ -29,6 +29,9 @@ class CurrentTimeRotatingFileHandler(logging.handlers.BaseRotatingHandler):
     :param delay: When True, the file opening is deferred until the first call to emit().
     :param errors: Used to determine how encoding errors are handled.
     """
+
+    __slots__ = ("dt", "filename", "delta", "count", "removed")
+
     def __init__(
             self,
             filename: str | None = None,

--- a/musify/log/logger.py
+++ b/musify/log/logger.py
@@ -17,6 +17,8 @@ from musify.log import INFO_EXTRA, REPORT, STAT
 class MusifyLogger(logging.Logger):
     """The logger for all logging operations in Musify."""
 
+    __slots__ = ()
+
     #: When true, never print a new line in the console when :py:meth:`print()` is called
     compact: bool = False
     #: When true, all bars returned by :py:meth:`get_progress_bar()` will be disabled by default
@@ -49,9 +51,6 @@ class MusifyLogger(logging.Logger):
             if isinstance(handler, logging.StreamHandler) and handler.stream == sys.stdout:
                 console_handlers.append(handler)
         return console_handlers
-
-    def __init__(self, name: str, level: int | str = logging.NOTSET):
-        super().__init__(name=name, level=level)
 
     def info_extra(self, msg, *args, **kwargs) -> None:
         """Log 'msg % args' with severity 'INFO_EXTRA'."""

--- a/musify/processors/base.py
+++ b/musify/processors/base.py
@@ -104,7 +104,7 @@ class DynamicProcessor(Processor, metaclass=ABCMeta):
 
     @property
     def processor_methods(self) -> frozenset[str]:
-        """String representation of the current processor name of this object"""
+        """String representation of all available processor names of this object"""
         return frozenset(self._processor_method_fmt(name) for name in self.__processormethods__)
 
     @classmethod

--- a/musify/processors/base.py
+++ b/musify/processors/base.py
@@ -16,6 +16,8 @@ from musify.utils import get_user_input, get_max_width, align_string
 class Processor(PrettyPrinter, metaclass=ABCMeta):
     """Generic base class for processors"""
 
+    __slots__ = ()
+
 
 class InputProcessor(Processor, metaclass=ABCMeta):
     """
@@ -23,6 +25,8 @@ class InputProcessor(Processor, metaclass=ABCMeta):
 
     Contains methods for getting user input and printing formatted options text to the terminal.
     """
+
+    __slots__ = ("logger",)
 
     def __init__(self):
         # noinspection PyTypeChecker
@@ -57,6 +61,7 @@ class dynamicprocessormethod:
     This assigns the method a processor method which can be dynamically called by the processor class.
     Optionally, provide a list of alternative names from which this processor method can also be called.
     """
+
     def __new__(cls, *args, **__):
         func: Optional[Callable] = next((a for a in args if callable(a)), None)
         self = partial(cls, *args) if func is None else super().__new__(cls)

--- a/musify/processors/compare.py
+++ b/musify/processors/compare.py
@@ -29,7 +29,7 @@ class Comparer(DynamicProcessor):
         An exception will be raised if this is True and reference object is not passed.
     """
 
-    __slots__ = ("_expected", "_converted", "field")
+    __slots__ = ("_expected", "_converted", "field", "reference_required")
 
     @classmethod
     def _processor_method_fmt(cls, name: str) -> str:

--- a/musify/processors/download.py
+++ b/musify/processors/download.py
@@ -27,6 +27,8 @@ class ItemDownloadHelper(InputProcessor):
     :param interval: The number of items to open sites for before pausing for user input.
     """
 
+    __slots__ = ("urls", "fields", "interval")
+
     def __init__(self, urls: UnitIterable[str] = (), fields: UnitIterable[Field] = Fields.ALL, interval: int = 1):
         super().__init__()
 

--- a/musify/processors/filter_matcher.py
+++ b/musify/processors/filter_matcher.py
@@ -46,7 +46,7 @@ class FilterMatcher[T: Any, U: Filter, V: Filter, X: FilterComparers](FilterComp
         from the matched items for any remaining unmatched items.
     """
 
-    __slots__ = ("include", "exclude", "comparers", "group_by")
+    __slots__ = ("logger", "include", "exclude", "comparers", "group_by")
 
     def __init__(
             self,

--- a/musify/processors/match.py
+++ b/musify/processors/match.py
@@ -78,8 +78,6 @@ class ItemMatcher(Processor):
     reduce_name_score_factor = 0.5
 
     def __init__(self):
-        super().__init__()
-
         # noinspection PyTypeChecker
         #: The :py:class:`MusifyLogger` for this  object
         self.logger: MusifyLogger = logging.getLogger(__name__)

--- a/musify/processors/sort.py
+++ b/musify/processors/sort.py
@@ -130,7 +130,6 @@ class ItemSorter(Processor):
             shuffle_mode: ShuffleMode | None = None,
             shuffle_weight: float = 0.0
     ):
-        super().__init__()
         fields = to_collection(fields, list) if isinstance(fields, Field) else fields
         self.sort_fields: dict[Field | None, bool] = {field: False for field in fields} \
             if isinstance(fields, Sequence) else fields

--- a/musify/processors/time.py
+++ b/musify/processors/time.py
@@ -13,6 +13,8 @@ from musify.processors.base import DynamicProcessor, dynamicprocessormethod
 class TimeMapper(DynamicProcessor, PrettyPrinter):
     """Map of time character representation to it unit conversion from seconds"""
 
+    __slots__ = ()
+
     @classmethod
     def _processor_method_fmt(cls, name: str) -> str:
         return name.casefold().strip()[0] if not name.startswith("min") else name

--- a/musify/utils.py
+++ b/musify/utils.py
@@ -14,6 +14,9 @@ from musify.types import Number
 
 class SafeDict(dict):
     """Extends dict to ignore missing keys when using format_map operations"""
+
+    __slots__ = ()
+
     def __missing__(self, key):
         return "{" + key + "}"
 

--- a/musify/utils.py
+++ b/musify/utils.py
@@ -1,9 +1,10 @@
 """
 Generic utility functions and classes which can be used throughout the entire package.
 """
+import inspect
 import re
 from collections import Counter
-from collections.abc import Iterable, Collection, MutableSequence, Mapping, MutableMapping
+from collections.abc import Iterable, Collection, MutableSequence, Mapping, MutableMapping, Callable
 from typing import Any
 
 import unicodedata
@@ -253,3 +254,11 @@ def get_most_common_values(values: Iterable[Any]) -> list[Any]:
 def get_user_input(text: str | None = None) -> str:
     """Print formatted dialog with optional text and get the user's input."""
     return input(f"\33[93m{text}\33[0m | ").strip()
+
+
+def clean_kwargs(func: Callable, kwargs: dict[str, Any]) -> None:
+    """Clean ``kwargs`` by removing any kwarg not in the signature of the given ``func``."""
+    signature = inspect.signature(func).parameters
+    for key in list(kwargs):
+        if key not in signature:
+            kwargs.pop(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 dependencies = [
     "mutagen~=1.47",
     "requests~=2.31",
-    "requests-cache~=1.1",
     "Pillow~=10.1",
     "python-dateutil>=2.8.2,<2.10.0",
     "xmltodict~=0.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ docs = [
     "sphinx~=7.2",
     "renku_sphinx_theme",
     "graphviz~=0.20",
-    "sphinx-autodoc-typehints>=1.25,<3.0",
+    "sphinx-autodoc-typehints~=2.1",
     "autodocsumm~=0.2",
     "sphinxext-opengraph~=0.9",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,5 +88,6 @@ minversion = "7.0"
 testpaths = ["tests"]
 addopts = "-color=yes"
 markers = [
+    "slow: marks test as slow (deselect with '-m \"not slow\"')",
     "manual: marks tests to be run only when manually directed to by the developer",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ docs = [
     "sphinx-autodoc-typehints~=2.1",
     "autodocsumm~=0.2",
     "sphinxext-opengraph~=0.9",
+    "matplotlib~=3.9",
 ]
 dev = [
     "musify[build,test,docs]",

--- a/tests/api/cache/backend/test_sqlite.py
+++ b/tests/api/cache/backend/test_sqlite.py
@@ -1,0 +1,161 @@
+import json
+import sqlite3
+from datetime import datetime, timedelta
+from random import randrange, choice
+from typing import Any
+
+import pytest
+from requests import Response, Request
+
+from musify.api.cache.backend.base import RequestSettings, PaginatedRequestSettings
+from musify.api.cache.backend.sqlite import SQLiteTable, SQLiteCache
+from tests.api.cache.backend.testers import ResponseRepositoryTester, ResponseCacheTester
+from tests.api.cache.backend.utils import MockRequestSettings, MockPaginatedRequestSettings
+from tests.utils import random_str
+
+REQUEST_SETTINGS = [
+    MockRequestSettings,
+    MockPaginatedRequestSettings,
+]
+
+class SQLiteTester:
+    @staticmethod
+    @pytest.fixture
+    def connection() -> sqlite3.Connection:
+        """Yields a valid :py:class:`Connection` to use throughout tests in this suite as a pytest.fixture."""
+        return sqlite3.Connection(database="file::memory:")
+
+
+class TestSQLiteTable(SQLiteTester, ResponseRepositoryTester):
+
+    @pytest.fixture(scope="class", params=REQUEST_SETTINGS)
+    def settings(self, request) -> RequestSettings:
+        cls: type[RequestSettings] = request.param
+        return cls(name="test")
+
+    @pytest.fixture
+    def repository(
+            self, settings: RequestSettings, connection: sqlite3.Connection, valid_items: dict, invalid_items: dict
+    ) -> SQLiteTable:
+        expire = timedelta(days=2)
+        repository = SQLiteTable(connection=connection, settings=settings, expire=expire)
+
+        query = "\n".join((
+            f"INSERT OR REPLACE INTO {settings.name} (",
+            f"\t{", ".join(repository._primary_key_columns)}, {repository.expiry_key}, {repository.data_key}",
+            ") ",
+            f"VALUES ({",".join("?" * len(repository._primary_key_columns))},?,?);",
+        ))
+        parameters = [
+            (*key, repository.expire.isoformat(), repository.serialise(value))
+            for key, value in valid_items.items()
+        ]
+        invalid_expire_dt = datetime.now() - expire  # expiry time in the past, response cache has expired
+        parameters.extend(
+            (*key, invalid_expire_dt.isoformat(), repository.serialise(value))
+            for key, value in invalid_items.items()
+        )
+        connection.executemany(query, parameters)
+
+        return repository
+
+    @property
+    def connection_closed_exception(self) -> type[Exception]:
+        return sqlite3.DatabaseError
+
+    @staticmethod
+    def generate_item(settings: RequestSettings) -> tuple[tuple, dict[str, Any]]:
+        key = ("GET", random_str(30, 50),)
+        value = {
+            random_str(10, 30): random_str(10, 30),
+            random_str(10, 30): randrange(0, 100),
+            str(randrange(0, 100)): random_str(10, 30),
+            str(randrange(0, 100)): randrange(0, 100),
+        }
+
+        if isinstance(settings, PaginatedRequestSettings):
+            key = (*key, randrange(0, 100), randrange(1, 50))
+
+        return key, value
+
+    @staticmethod
+    def generate_response_from_item(key: tuple, value: dict[str, Any]) -> Response:
+        url = f"http://test.com/{key[1]}"
+        params = {}
+        if len(key) == 4:
+            params["offset"] = key[2]
+            params["page_count"] = key[3]
+
+        request = Request(method=key[0], url=url, params=params).prepare()
+
+        response = Response()
+        response.encoding = "utf-8"
+        response._content = json.dumps(value).encode(response.encoding)
+        response.status_code = 200
+        response.url = request.url
+        response.request = request
+
+        return response
+
+    def test_init(self, connection: sqlite3.Connection):
+        settings = MockRequestSettings(name="test")
+        SQLiteTable(connection=connection, settings=settings)
+
+        cur = connection.execute(
+            f"SELECT name FROM sqlite_master WHERE type='table' AND name='{settings.name}'"
+        )
+        rows = cur.fetchall()
+
+        assert len(rows) == 1
+        assert rows[0][0] == settings.name
+
+    def test_serialise(self, repository: SQLiteTable):
+        _, value = self.generate_item(repository.settings)
+        value_serialised = repository.serialise(value)
+
+        assert isinstance(value_serialised, str)
+        assert repository.serialise(value_serialised) == value_serialised
+
+    def test_deserialise(self, repository: SQLiteTable):
+        _, value = self.generate_item(repository.settings)
+        value_str = json.dumps(value)
+        value_deserialised = repository.deserialise(value_str)
+
+        assert isinstance(value_deserialised, dict)
+        assert repository.deserialise(value_deserialised) == value
+
+
+class TestSQLiteCache(SQLiteTester, ResponseCacheTester):
+
+    @pytest.fixture
+    def cache(self, connection: sqlite3.Connection) -> SQLiteCache:
+        cache = SQLiteCache(cache_name="test", connection=connection)
+        cache.repository_getter = self.get_repository_for_url
+
+        for _ in range(randrange(5, 10)):
+            settings = choice(REQUEST_SETTINGS)(name=random_str(20, 30))
+            items = dict(TestSQLiteTable.generate_item(settings) for _ in range(randrange(3, 6)))
+
+            repository = SQLiteTable(settings=settings, connection=connection)
+            repository.update(items)
+            cache[settings.name] = repository
+
+        return cache
+
+    @staticmethod
+    def get_repository_for_url(cache: SQLiteCache, url: str) -> SQLiteCache | None:
+        for name, repository in cache.items():
+            if name == repository.settings.get_id(url):
+                return repository
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_connect_with_path(self):
+        pass  # TODO
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_connect_with_in_memory_db(self):
+        pass  # TODO
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_connect_with_temp_db(self):
+        pass  # TODO

--- a/tests/api/cache/backend/test_sqlite.py
+++ b/tests/api/cache/backend/test_sqlite.py
@@ -22,7 +22,7 @@ class SQLiteTester(BaseResponseTester):
 
     @staticmethod
     def generate_connection() -> sqlite3.Connection:
-        return sqlite3.Connection(database="file::memory:")
+        return sqlite3.Connection(database=":memory:")
 
     @staticmethod
     def generate_item(settings: RequestSettings) -> tuple[tuple, dict[str, Any]]:

--- a/tests/api/cache/backend/test_sqlite.py
+++ b/tests/api/cache/backend/test_sqlite.py
@@ -45,7 +45,7 @@ class SQLiteTester(BaseResponseTester):
         params = {}
         if len(key) == 4:
             params["offset"] = key[2]
-            params["page_count"] = key[3]
+            params["size"] = key[3]
 
         request = Request(method=key[0], url=url, params=params).prepare()
 

--- a/tests/api/cache/backend/test_sqlite.py
+++ b/tests/api/cache/backend/test_sqlite.py
@@ -70,7 +70,7 @@ class TestSQLiteTable(SQLiteTester, ResponseRepositoryTester):
 
         query = "\n".join((
             f"INSERT OR REPLACE INTO {settings.name} (",
-            f"\t{", ".join(repository._primary_key_columns)}, {repository.expiry_key}, {repository.data_key}",
+            f"\t{", ".join(repository._primary_key_columns)}, {repository.expiry_column}, {repository.data_column}",
             ") ",
             f"VALUES ({",".join("?" * len(repository._primary_key_columns))},?,?);",
         ))

--- a/tests/api/cache/backend/test_sqlite.py
+++ b/tests/api/cache/backend/test_sqlite.py
@@ -18,6 +18,7 @@ REQUEST_SETTINGS = [
     MockPaginatedRequestSettings,
 ]
 
+
 class SQLiteTester:
     @staticmethod
     @pytest.fixture

--- a/tests/api/cache/backend/testers.py
+++ b/tests/api/cache/backend/testers.py
@@ -1,0 +1,282 @@
+from abc import ABC, abstractmethod
+from random import choice, randrange
+from typing import Any
+
+import pytest
+from requests import Response
+
+from musify.api.cache.backend.base import ResponseRepository, Connection, ResponseCache, RequestSettings
+from musify.exception import MusifyKeyError
+
+
+class ResponseRepositoryTester(ABC):
+
+    @staticmethod
+    @abstractmethod
+    def generate_item(settings: RequestSettings) -> tuple[Any, Any]:
+        """
+        Randomly generates an item (key, value) appropriate for this repository type
+        that can be persisted to the repository.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def generate_response_from_item(key: Any, value: Any) -> Response:
+        """
+        Generates a :py:class:`Response` appropriate for this repository type from the given ``key`` and ``value``
+        that can be persisted to the repository.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def settings(self, request) -> RequestSettings:
+        """
+        Yields the :py:class:`RequestSettings` to use when creating a new :py:class:`ResponseRepository`
+        as a pytest.fixture.
+        """
+        raise NotImplementedError
+
+    @pytest.fixture(scope="class")
+    def valid_items(self, settings: RequestSettings) -> dict:
+        """Yields expected items to be found in the repository that have not expired as a pytest.fixture."""
+        return dict(self.generate_item(settings) for _ in range(randrange(3, 6)))
+
+    @pytest.fixture(scope="class")
+    def invalid_items(self, settings: RequestSettings) -> dict:
+        """Yields expected items to be found in the repository that have passed the expiry time as a pytest.fixture."""
+        return dict(self.generate_item(settings) for _ in range(randrange(3, 6)))
+
+    @pytest.fixture(scope="class")
+    def items(self, valid_items: dict, invalid_items: dict) -> dict:
+        """Yields all expected items to be found in the repository as a pytest.fixture."""
+        return valid_items | invalid_items
+
+    @staticmethod
+    @abstractmethod
+    def connection() -> Connection:
+        """Yields a valid :py:class:`Connection` to use throughout tests in this suite as a pytest.fixture."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def repository(self, request, connection: Connection, valid_items: dict, invalid_items: dict) -> ResponseRepository:
+        """
+        Yields a valid :py:class:`ResponseRepository` to use throughout tests in this suite as a pytest.fixture.
+        Should produce a repository for each type of :py:class:`RequestSettings` type
+        as given by the request fixture.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def connection_closed_exception(self) -> type[Exception]:
+        """Returns the exception class to expect when executing against a closed connection."""
+        raise NotImplementedError
+
+    def test_close(self, repository: ResponseRepository):
+        key = next(iter(repository))
+        repository.close()
+
+        with pytest.raises(self.connection_closed_exception):
+            repository.get_response(key)
+
+    @staticmethod
+    def test_count(repository: ResponseRepository, items: dict, valid_items: dict):
+        assert len(repository) == len(items)
+        assert repository.count() == len(items)
+        assert repository.count(False) == len(valid_items)
+
+    @abstractmethod
+    def test_serialise(self, repository: ResponseRepository):
+        raise NotImplementedError
+
+    @abstractmethod
+    def test_deserialise(self, repository: ResponseRepository):
+        raise NotImplementedError
+
+    def test_get_key_from_request(self, repository: ResponseRepository):
+        key, value = self.generate_item(repository.settings)
+        request = self.generate_response_from_item(key, value).request
+        assert repository.get_key_from_request(request) == key
+
+    def test_get_response_on_missing(self, repository: ResponseRepository, valid_items: dict):
+        key, value = self.generate_item(repository.settings)
+        assert key not in repository
+
+        with pytest.raises(MusifyKeyError):
+            assert repository[key]
+
+        assert repository.get(key) is None
+        assert repository.get_response(key) is None
+        assert repository.get_responses(list(valid_items) + [key]) == list(valid_items.values())
+
+    @staticmethod
+    def test_get_response_from_key(repository: ResponseRepository, valid_items: dict):
+        key, value = choice(list(valid_items.items()))
+
+        assert repository[key] == value
+        assert repository.get(key) == value
+        assert repository.get_response(key) == value
+
+    @staticmethod
+    def test_get_responses_from_keys(repository: ResponseRepository, valid_items: dict):
+        assert repository.get_responses(valid_items.keys()) == list(valid_items.values())
+
+    def test_get_response_from_request(self, repository: ResponseRepository, valid_items: dict):
+        key, value = choice(list(valid_items.items()))
+        request = self.generate_response_from_item(key, value).request
+        assert repository.get_response(request) == value
+
+    def test_get_responses_from_requests(self, repository: ResponseRepository, valid_items: dict):
+        requests = [self.generate_response_from_item(key, value).request for key, value in valid_items.items()]
+        assert repository.get_responses(requests) == list(valid_items.values())
+
+    def test_get_response_from_response(self, repository: ResponseRepository, valid_items: dict):
+        key, value = choice(list(valid_items.items()))
+        response = self.generate_response_from_item(key, value)
+        assert repository.get_response(response) == value
+
+    def test_get_responses_from_responses(self, repository: ResponseRepository, valid_items: dict):
+        responses = [self.generate_response_from_item(key, value) for key, value in valid_items.items()]
+        assert repository.get_responses(responses) == list(valid_items.values())
+
+    def test_save_response_from_key(self, repository: ResponseRepository):
+        key, value = self.generate_item(repository.settings)
+        assert key not in repository
+
+        repository[key] = value
+        assert key in repository
+        assert repository[key] == value
+
+    def test_save_responses_from_dict(self, repository: ResponseRepository):
+        items = dict(self.generate_item(repository.settings) for _ in range(randrange(3, 6)))
+        assert all(key not in repository for key in items)
+
+        repository.update(items)
+        assert all(key in repository for key in items)
+        for key, value in items.items():
+            assert repository[key] == value
+
+    def test_save_response(self, repository: ResponseRepository):
+        key, value = self.generate_item(repository.settings)
+        response = self.generate_response_from_item(key, value)
+        assert key not in repository
+
+        repository.save_response(response)
+        assert key in repository
+        assert repository[key] == value
+
+    def test_save_responses(self, repository: ResponseRepository):
+        items = dict(self.generate_item(repository.settings) for _ in range(randrange(3, 6)))
+        responses = [self.generate_response_from_item(key, value) for key, value in items.items()]
+        assert all(key not in repository for key in items)
+
+        repository.save_responses(responses)
+        assert all(key in repository for key in items)
+        for key, value in items.items():
+            assert repository[key] == value
+
+    def test_delete_response_on_missing(self, repository: ResponseRepository):
+        key, value = self.generate_item(repository.settings)
+        assert key not in repository
+
+        with pytest.raises(MusifyKeyError):
+            del repository[key]
+
+        repository.delete_response(key)
+
+    def test_delete_response_from_key(self, repository: ResponseRepository, valid_items: dict):
+        key, value = choice(list(valid_items.items()))
+        assert key in repository
+
+        del repository[key]
+        assert key not in repository
+
+    def test_delete_response_from_request(self, repository: ResponseRepository, valid_items: dict):
+        key, value = choice(list(valid_items.items()))
+        request = self.generate_response_from_item(key, value).request
+        assert key in repository
+
+        repository.delete_response(request)
+        assert key not in repository
+
+    def test_delete_responses_from_requests(self, repository: ResponseRepository, valid_items: dict):
+        requests = [self.generate_response_from_item(key, value).request for key, value in valid_items.items()]
+        for key in valid_items:
+            assert key in repository
+
+        repository.delete_responses(requests)
+        for key in valid_items:
+            assert key not in repository
+
+    def test_delete_response_from_response(self, repository: ResponseRepository, valid_items: dict):
+        key, value = choice(list(valid_items.items()))
+        response = self.generate_response_from_item(key, value)
+        assert key in repository
+
+        repository.delete_response(response)
+        assert key not in repository
+
+    def test_delete_responses_from_responses(self, repository: ResponseRepository, valid_items: dict):
+        responses = [self.generate_response_from_item(key, value) for key, value in valid_items.items()]
+        for key in valid_items:
+            assert key in repository
+
+        repository.delete_responses(responses)
+        for key in valid_items:
+            assert key not in repository
+
+    @staticmethod
+    def test_mapping_functionality(repository: ResponseRepository, items: dict):
+        key, value = choice(list(repository.items()))
+        assert key in items
+        assert items[key] == value
+
+        repository.clear()
+        assert key not in repository
+        with pytest.raises(MusifyKeyError):
+            assert repository[key]
+
+        # TODO: add more here
+
+
+class ResponseCacheTester:
+
+    @abstractmethod
+    def connection(self) -> Connection:
+        """Yields a valid :py:class:`Connection` to use throughout tests in this suite as a pytest.fixture."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def cache(self, connection: Connection) -> ResponseCache:
+        """Yields a valid :py:class:`ResponseCache` to use throughout tests in this suite as a pytest.fixture."""
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def get_repository_for_url(cache: ResponseCache, url: str) -> ResponseCache:
+        """Returns a repository for the given ``url`` from the given ``cache``."""
+        raise NotImplementedError
+
+    def test_close(self, cache: ResponseCache):
+        key = choice(list(cache.values()))
+        cache.close()
+
+        with pytest.raises(Exception):
+            cache.get_response(key)
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_create_repository(self, cache: ResponseCache):
+        pass  # TODO
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_get_repository_for_url(self, cache: ResponseCache):
+        pass  # TODO
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_get_repository_for_requests(self, cache: ResponseCache):
+        pass  # TODO
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_repository_operations(self, cache: ResponseCache):
+        pass  # TODO

--- a/tests/api/cache/backend/testers.py
+++ b/tests/api/cache/backend/testers.py
@@ -102,7 +102,7 @@ class ResponseRepositoryTester(BaseResponseTester, ABC):
 
     @staticmethod
     def test_count(repository: ResponseRepository, items: dict, valid_items: dict):
-        assert len(repository) == len(items)
+        assert len(repository) == len(valid_items)
         assert repository.count() == len(items)
         assert repository.count(False) == len(valid_items)
 

--- a/tests/api/cache/backend/utils.py
+++ b/tests/api/cache/backend/utils.py
@@ -35,4 +35,4 @@ class MockPaginatedRequestSettings(MockRequestSettings, PaginatedRequestSettings
     @staticmethod
     def get_limit(url: str) -> int:
         params = parse_qs(urlparse(url).query)
-        return int(params.get("page_count", [0])[0])
+        return int(params.get("size", [0])[0])

--- a/tests/api/cache/backend/utils.py
+++ b/tests/api/cache/backend/utils.py
@@ -1,0 +1,19 @@
+from urllib.parse import parse_qs, urlparse
+
+from musify.api.cache.backend.base import RequestSettings, PaginatedRequestSettings
+
+
+class MockRequestSettings(RequestSettings):
+
+    def get_id(self, url: str) -> str:
+        return urlparse(url).path.split("/")[-1]
+
+
+class MockPaginatedRequestSettings(MockRequestSettings, PaginatedRequestSettings):
+    def get_offset(self, url: str) -> int:
+        params = parse_qs(urlparse(url).query)
+        return int(params.get("offset", [0])[0])
+
+    def get_limit(self, url: str) -> int:
+        params = parse_qs(urlparse(url).query)
+        return int(params.get("page_count", [0])[0])

--- a/tests/api/cache/backend/utils.py
+++ b/tests/api/cache/backend/utils.py
@@ -4,7 +4,6 @@ from musify.api.cache.backend.base import RequestSettings, PaginatedRequestSetti
 
 
 class MockRequestSettings(RequestSettings):
-
     def get_id(self, url: str) -> str:
         return urlparse(url).path.split("/")[-1]
 

--- a/tests/api/cache/backend/utils.py
+++ b/tests/api/cache/backend/utils.py
@@ -1,18 +1,38 @@
+import json
+from typing import Any
 from urllib.parse import parse_qs, urlparse
+
+from requests import Response
 
 from musify.api.cache.backend.base import RequestSettings, PaginatedRequestSettings
 
 
 class MockRequestSettings(RequestSettings):
-    def get_id(self, url: str) -> str:
+
+    @staticmethod
+    def get_name(value: Any) -> str | None:
+        if isinstance(value, dict):
+            return value.get("name")
+        elif isinstance(value, Response):
+            try:
+                return value.json().get("name")
+            except json.decoder.JSONDecodeError:
+                pass
+
+    @staticmethod
+    def get_id(url: str) -> str | None:
+        if "/" not in url:
+            return
         return urlparse(url).path.split("/")[-1]
 
 
 class MockPaginatedRequestSettings(MockRequestSettings, PaginatedRequestSettings):
-    def get_offset(self, url: str) -> int:
+    @staticmethod
+    def get_offset(url: str) -> int:
         params = parse_qs(urlparse(url).query)
         return int(params.get("offset", [0])[0])
 
-    def get_limit(self, url: str) -> int:
+    @staticmethod
+    def get_limit(url: str) -> int:
         params = parse_qs(urlparse(url).query)
         return int(params.get("page_count", [0])[0])

--- a/tests/api/cache/test_session.py
+++ b/tests/api/cache/test_session.py
@@ -1,22 +1,63 @@
-import sqlite3
+from random import choice
 
 import pytest
+from requests_mock import Mocker
 
 from musify.api.cache.backend.base import ResponseCache, Connection
-from tests.api.cache.backend.test_sqlite import TestSQLiteCache
+from musify.api.cache.session import CachedSession
+from tests.api.cache.backend.test_sqlite import TestSQLiteCache as SQLiteCacheTester
 from tests.api.cache.backend.testers import ResponseCacheTester
 
 
 class TestCachedSession:
 
-    @pytest.fixture(scope="class", params=[
-        (TestSQLiteCache, sqlite3.Connection(database="file::memory:"))
-    ])
-    def cache(self, request) -> ResponseCache:
+    @pytest.fixture(scope="class", params=[SQLiteCacheTester])
+    def tester(self, request) -> ResponseCacheTester:
+        return request.param
+
+    @pytest.fixture(scope="class")
+    def connection(self, tester: ResponseCacheTester) -> Connection:
+        """Yields a valid :py:class:`Connection` to use throughout tests in this suite as a pytest.fixture."""
+        return tester.generate_connection()
+
+    @pytest.fixture(scope="class")
+    def cache(self, tester: ResponseCacheTester, connection: Connection) -> ResponseCache:
         """Yields a valid :py:class:`ResponseCache` to use throughout tests in this suite as a pytest.fixture."""
-        tester: ResponseCacheTester = request.param[0]
-        connection: Connection = request.param[1]
         return tester.generate_cache(connection=connection)
 
-    def test_request(self, cache: ResponseCache):
-        pass  # TODO
+    @pytest.fixture(scope="class")
+    def session(self, cache: ResponseCache) -> CachedSession:
+        """
+        Yields a valid :py:class:`CachedSession` with the given ``cache``
+        to use throughout tests in this suite as a pytest.fixture.
+        """
+        return CachedSession(cache=cache)
+
+    def test_request(
+            self,
+            session: CachedSession,
+            cache: ResponseCache,
+            tester: ResponseCacheTester,
+            requests_mock: Mocker
+    ):
+        repository = choice(list(cache.values()))
+
+        key, value = choice(list(repository.items()))
+        expected = tester.generate_response_from_item(repository.settings, key, value)
+        request = expected.request
+        assert key in repository
+
+        response = session.request(method=request.method, url=request.url)
+        assert response.text == expected.text
+        assert not requests_mock.request_history
+
+        expected = tester.generate_response(repository.settings)
+        request = expected.request
+        key = repository.get_key_from_request(request)
+        assert key not in repository
+        requests_mock.get(request.url, json=expected.json())
+
+        response = session.request(method=request.method, url=request.url)
+        assert response.text == expected.text
+        assert len(requests_mock.request_history) == 1
+        assert key in repository

--- a/tests/api/cache/test_session.py
+++ b/tests/api/cache/test_session.py
@@ -48,7 +48,7 @@ class TestCachedSession:
         assert key in repository
 
         response = session.request(method=request.method, url=request.url)
-        assert response.text == expected.text
+        assert response.json() == expected.json()
         assert len(requests_mock.request_history) == 0
 
     def test_request_not_cached(
@@ -66,7 +66,7 @@ class TestCachedSession:
         requests_mock.get(request.url, json=expected.json())
 
         response = session.request(method=request.method, url=request.url, persist=False)
-        assert response.text == expected.text
+        assert response.json() == expected.json()
         assert len(requests_mock.request_history) == 1
         assert key not in repository
 
@@ -76,5 +76,5 @@ class TestCachedSession:
         assert key in repository
 
         response = session.request(method=request.method, url=request.url)
-        assert response.text == expected.text
+        assert response.json() == expected.json()
         assert len(requests_mock.request_history) == 2

--- a/tests/api/cache/test_session.py
+++ b/tests/api/cache/test_session.py
@@ -2,29 +2,21 @@ import sqlite3
 
 import pytest
 
-from musify.api.cache.backend.base import ResponseCache
-from musify.api.cache.backend.sqlite import SQLiteCache
+from musify.api.cache.backend.base import ResponseCache, Connection
+from tests.api.cache.backend.test_sqlite import TestSQLiteCache
+from tests.api.cache.backend.testers import ResponseCacheTester
 
 
 class TestCachedSession:
 
     @pytest.fixture(scope="class", params=[
-        SQLiteCache(cache_name="test", connection=sqlite3.Connection(database="file::memory:?cache=shared"))
+        (TestSQLiteCache, sqlite3.Connection(database="file::memory:"))
     ])
     def cache(self, request) -> ResponseCache:
         """Yields a valid :py:class:`ResponseCache` to use throughout tests in this suite as a pytest.fixture."""
+        tester: ResponseCacheTester = request.param[0]
+        connection: Connection = request.param[1]
+        return tester.generate_cache(connection=connection)
 
-        def get_repository_for_url(cache: ResponseCache, url: str) -> ResponseCache:
-            """Returns a repository for the given ``url`` from the given ``cache``."""
-            pass  # TODO
-
-        response_cache: ResponseCache = request.param
-
-        # TODO: set up repositories on cache
-
-        response_cache.repository_getter = get_repository_for_url
-        return response_cache
-
-    @pytest.mark.skip(reason="Not yet implemented")
     def test_request(self, cache: ResponseCache):
         pass  # TODO

--- a/tests/api/cache/test_session.py
+++ b/tests/api/cache/test_session.py
@@ -1,0 +1,30 @@
+import sqlite3
+
+import pytest
+
+from musify.api.cache.backend.base import ResponseCache
+from musify.api.cache.backend.sqlite import SQLiteCache
+
+
+class TestCachedSession:
+
+    @pytest.fixture(scope="class", params=[
+        SQLiteCache(cache_name="test", connection=sqlite3.Connection(database="file::memory:?cache=shared"))
+    ])
+    def cache(self, request) -> ResponseCache:
+        """Yields a valid :py:class:`ResponseCache` to use throughout tests in this suite as a pytest.fixture."""
+
+        def get_repository_for_url(cache: ResponseCache, url: str) -> ResponseCache:
+            """Returns a repository for the given ``url`` from the given ``cache``."""
+            pass  # TODO
+
+        response_cache: ResponseCache = request.param
+
+        # TODO: set up repositories on cache
+
+        response_cache.repository_getter = get_repository_for_url
+        return response_cache
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_request(self, cache: ResponseCache):
+        pass  # TODO

--- a/tests/api/test_authorise.py
+++ b/tests/api/test_authorise.py
@@ -217,7 +217,7 @@ class TestAPIAuthoriser:
         response = {"access_token": "valid token", "expires_in": 3000, "refresh_token": "new_refresh"}
         requests_mock.post(authoriser.auth_args["url"], json=response)
 
-        authoriser.authorise()
+        authoriser()
         expected_header = {"Authorization": "Bearer valid token"}
         assert authoriser.headers == expected_header
         assert authoriser.token["refresh_token"] == "new_refresh"
@@ -233,7 +233,7 @@ class TestAPIAuthoriser:
         requests_mock.get(authoriser.test_args["url"], json={"test": "valid"})
 
         # loads token, token is valid, no refresh needed
-        authoriser.authorise()
+        authoriser()
         expected_header = {"Authorization": f"Bearer {authoriser.token["access_token"]}"}
         assert authoriser.headers == expected_header
 
@@ -248,7 +248,7 @@ class TestAPIAuthoriser:
         )
 
         # force load from json despite being given token
-        authoriser.authorise(force_load=True)
+        authoriser(force_load=True)
         expected_header = {"new_key": f"prefix - {authoriser.token["access_token"]}"}
 
         assert authoriser.headers == expected_header | authoriser.header_extra
@@ -258,7 +258,7 @@ class TestAPIAuthoriser:
 
         # force new despite being given token and token file path
         with pytest.raises(APIError):
-            authoriser.authorise(force_new=True)
+            authoriser(force_new=True)
 
     def test_auth_new_token_and_no_refresh(self, token: dict[str, Any], token_file_path: str, requests_mock: Mocker):
         authoriser = APIAuthoriser(
@@ -269,7 +269,7 @@ class TestAPIAuthoriser:
 
         requests_mock.post(authoriser.auth_args["url"], json={"1": {"2": {"code": "token"}}})
 
-        authoriser.authorise()
+        authoriser()
         expected_header = {"Authorization": "Bearer token"}
         assert authoriser.headers == expected_header
 
@@ -285,7 +285,7 @@ class TestAPIAuthoriser:
         response = {"get_token": "valid token", "expires_in": 3000, "refresh_token": "new_refresh"}
         requests_mock.post(authoriser.refresh_args["url"], json=response)
 
-        authoriser.authorise()
+        authoriser()
         expected_header = {"Authorization": "Bearer valid token"}
         assert authoriser.headers == expected_header
         assert authoriser.token["refresh_token"] == "new_refresh"
@@ -305,19 +305,19 @@ class TestAPIAuthoriser:
         requests_mock.post(authoriser.refresh_args["url"], json=response)
 
         with pytest.raises(APIError):
-            authoriser.authorise()
+            authoriser()
 
         authoriser.auth_args = {"url": "http://localhost/auth"}
         response = {"get_token": "valid token", "expires_in": 20, "refresh_token": "new_refresh"}
         requests_mock.post(authoriser.auth_args["url"], json=response)
 
         with pytest.raises(APIError):
-            authoriser.authorise()
+            authoriser()
 
         response = {"get_token": "valid token", "expires_in": 3000, "refresh_token": "new_refresh"}
         requests_mock.post(authoriser.auth_args["url"], json=response)
 
-        authoriser.authorise()
+        authoriser()
         expected_header = {"Authorization": "Bearer valid token"}
         assert authoriser.headers == expected_header
         assert authoriser.token["refresh_token"] == "new_refresh"

--- a/tests/api/test_request.py
+++ b/tests/api/test_request.py
@@ -1,8 +1,5 @@
 import json
 from dataclasses import dataclass
-from datetime import timedelta
-from os.path import join
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -119,14 +116,14 @@ class TestRequestHandler:
             def get_id(self, url: str):
                 return url.split("/")[-1]
 
-        url = "http://localhost/test"
+        test_url = "http://localhost/test"
         expected_json = {"key": "value"}
-        requests_mock.get(url, json=expected_json)
+        requests_mock.get(test_url, json=expected_json)
 
         storage = request_handler.cache.create_storage(MockRequestSettings(name="test"))
         request_handler.cache.storage_getter = lambda _, __: storage
 
-        response = request_handler._request(method="GET", url=url)
+        response = request_handler._request(method="GET", url=test_url)
         assert response.json() == expected_json
         assert requests_mock.call_count == 1
 
@@ -134,12 +131,12 @@ class TestRequestHandler:
         keys = storage.get_key_from_request(response.request)
         assert storage.get_response(keys)
 
-        response = request_handler._request(method="GET", url=url)
+        response = request_handler._request(method="GET", url=test_url)
         assert response.json() == expected_json
         assert requests_mock.call_count == 1
 
         storage.clear()
-        response = request_handler._request(method="GET", url=url)
+        response = request_handler._request(method="GET", url=test_url)
         assert response.json() == expected_json
         assert requests_mock.call_count == 2
 

--- a/tests/api/test_request.py
+++ b/tests/api/test_request.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import dataclass
 from datetime import timedelta
 from os.path import join
 from pathlib import Path
@@ -7,13 +8,16 @@ from typing import Any
 import pytest
 import requests
 from requests import Response
-from requests_cache import OriginalResponse, CachedResponse, CachedSession
 from requests_mock import Mocker
 # noinspection PyProtectedMember,PyUnresolvedReferences
 from requests_mock.request import _RequestObjectProxy as Request
 # noinspection PyProtectedMember,PyUnresolvedReferences
 from requests_mock.response import _Context as Context
 
+from musify.api.authorise import APIAuthoriser
+from musify.api.cache.backend.base import ResponseCache, RequestSettings
+from musify.api.cache.backend.sqlite import SQLiteCache
+from musify.api.cache.session import CachedSession
 from musify.api.exception import APIError
 from musify.api.request import RequestHandler
 
@@ -21,9 +25,19 @@ from musify.api.request import RequestHandler
 class TestRequestHandler:
 
     @pytest.fixture
-    def request_handler(self, token: dict[str, Any], tmp_path: Path) -> RequestHandler:
+    def authoriser(self, token: dict[str, Any]) -> APIAuthoriser:
+        """Yield a simple :py:class:`APIAuthoriser` object"""
+        return APIAuthoriser(name="test", token=token)
+
+    @pytest.fixture
+    def cache(self) -> ResponseCache:
+        """Yield a simple :py:class:`ResponseCache` object"""
+        return SQLiteCache.connect_with_in_memory_db()
+
+    @pytest.fixture
+    def request_handler(self, authoriser: APIAuthoriser, cache: ResponseCache) -> RequestHandler:
         """Yield a simple :py:class:`RequestHandler` object"""
-        return RequestHandler(name="test", token=token, cache_path=join(tmp_path, "api_cache"))
+        return RequestHandler(authoriser=authoriser, cache=cache)
 
     @pytest.fixture
     def token(self) -> dict[str, Any]:
@@ -35,25 +49,21 @@ class TestRequestHandler:
         }
 
     # noinspection PyTestUnpassedFixture
-    def test_init(self, token: dict[str, Any], tmp_path: Path):
-        request_handler = RequestHandler(name="test", token=token, cache_path=None)
+    def test_init(self, token: dict[str, Any], authoriser: APIAuthoriser, cache: ResponseCache):
+        request_handler = RequestHandler(authoriser=authoriser)
+        assert request_handler.authoriser.token == token
         assert not isinstance(request_handler.session, CachedSession)
 
-        cache_path = join(tmp_path, "test")
-        cache_expiry = timedelta(days=6)
-        request_handler = RequestHandler(name="test", token=token, cache_expiry=cache_expiry, cache_path=cache_path)
+        request_handler = RequestHandler(authoriser=authoriser, cache=cache)
         assert isinstance(request_handler.session, CachedSession)
-        assert request_handler.token == token
-        assert request_handler.session.cache.cache_name == cache_path
-        assert request_handler.session.expire_after == cache_expiry
 
         request_handler.authorise()
-        for k, v in request_handler.headers.items():
+        for k, v in request_handler.authoriser.headers.items():
             assert request_handler.session.headers.get(k) == v
 
-    def test_context_management(self, token: dict[str, Any], tmp_path: Path):
-        with RequestHandler(name="test", token=token, cache_path=None) as handler:
-            for k, v in handler.headers.items():
+    def test_context_management(self, authoriser: APIAuthoriser):
+        with RequestHandler(authoriser=authoriser) as handler:
+            for k, v in handler.authoriser.headers.items():
                 assert handler.session.headers.get(k) == v
 
     def test_check_response_codes(self, request_handler: RequestHandler):
@@ -104,22 +114,32 @@ class TestRequestHandler:
         assert request_handler._response_as_json(response) == expected
 
     def test_cache_usage(self, request_handler: RequestHandler, requests_mock: Mocker):
+        @dataclass
+        class MockRequestSettings(RequestSettings):
+            def get_id(self, url: str):
+                return url.split("/")[-1]
+
         url = "http://localhost/test"
         expected_json = {"key": "value"}
         requests_mock.get(url, json=expected_json)
 
-        response = request_handler._request(method="GET", url=url, use_cache=True)
-        assert isinstance(response, OriginalResponse)
+        storage = request_handler.cache.create_storage(MockRequestSettings(name="test"))
+        request_handler.cache.storage_getter = lambda _, __: storage
+
+        response = request_handler._request(method="GET", url=url)
         assert response.json() == expected_json
         assert requests_mock.call_count == 1
 
-        response = request_handler._request(method="GET", url=url, use_cache=True)
-        assert isinstance(response, CachedResponse)
+        storage.save_response(response)
+        keys = storage.get_key_from_request(response.request)
+        assert storage.get_response(keys)
+
+        response = request_handler._request(method="GET", url=url)
         assert response.json() == expected_json
         assert requests_mock.call_count == 1
 
-        response = request_handler._request(method="GET", url=url, use_cache=False)
-        assert isinstance(response, OriginalResponse)
+        storage.clear()
+        response = request_handler._request(method="GET", url=url)
         assert response.json() == expected_json
         assert requests_mock.call_count == 2
 
@@ -137,23 +157,23 @@ class TestRequestHandler:
         expected_json = {"key": "value"}
 
         requests_mock.get(url, json=expected_json)
-        assert request_handler.request(method="GET", url=url, use_cache=False) == expected_json
+        assert request_handler.request(method="GET", url=url) == expected_json
 
         # ignore headers on good status code
         requests_mock.post(url, status_code=200, headers={"retry-after": "2000"}, json=expected_json)
-        assert request_handler.request(method="POST", url=url, use_cache=False) == expected_json
+        assert request_handler.request(method="POST", url=url) == expected_json
 
         # fail on long wait time
         requests_mock.put(url, status_code=429, headers={"retry-after": "2000"})
         assert request_handler.timeout < 2000
         with pytest.raises(APIError):
-            request_handler.put(url=url, use_cache=False)
+            request_handler.put(url=url)
 
         # fail on breaking status code
         requests_mock.delete(url, status_code=400)
         assert request_handler.timeout < 2000
         with pytest.raises(APIError):
-            request_handler.delete(method="GET", url=url, use_cache=False)
+            request_handler.delete(method="GET", url=url)
 
     def test_backoff(self, request_handler: RequestHandler, requests_mock: Mocker):
         url = "http://localhost/test"
@@ -175,5 +195,5 @@ class TestRequestHandler:
             return expected_json
 
         requests_mock.patch(url, json=backoff)
-        assert request_handler.patch(url=url, use_cache=False) == expected_json
+        assert request_handler.patch(url=url) == expected_json
         assert requests_mock.call_count == backoff_limit

--- a/tests/api/test_request.py
+++ b/tests/api/test_request.py
@@ -1,5 +1,4 @@
 import json
-from dataclasses import dataclass
 from typing import Any
 
 import pytest
@@ -12,7 +11,7 @@ from requests_mock.request import _RequestObjectProxy as Request
 from requests_mock.response import _Context as Context
 
 from musify.api.authorise import APIAuthoriser
-from musify.api.cache.backend.base import ResponseCache, RequestSettings
+from musify.api.cache.backend.base import ResponseCache
 from musify.api.cache.backend.sqlite import SQLiteCache
 from musify.api.cache.session import CachedSession
 from musify.api.exception import APIError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,7 +282,7 @@ def path(request: pytest.FixtureRequest | SubRequest, tmp_path: Path) -> str:
 
 @pytest.fixture(scope="session", params=ALL_ITEM_TYPES, ids=idfn)
 def object_type(request) -> RemoteObjectType:
-    """Yields the valid :py:class:`RemoteObjectTypes` to use throughout tests in this suite as a pytest.fixture"""
+    """Yields the valid :py:class:`RemoteObjectTypes` to use throughout tests in this suite as a pytest.fixture."""
     return request.param
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ import yaml
 from _pytest.fixtures import SubRequest
 
 from musify import MODULE_ROOT
-from musify.api.request import RequestHandler
 from musify.libraries.remote.core.enum import RemoteObjectType
 from musify.libraries.remote.spotify.api import SpotifyAPI
 from musify.libraries.remote.spotify.processors import SpotifyDataWrangler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,8 +297,11 @@ def spotify_wrangler():
 def spotify_api() -> SpotifyAPI:
     """Yield an authorised :py:class:`SpotifyAPI` object"""
     token = {"access_token": "fake access token", "token_type": "Bearer", "scope": "test-read"}
-    api = SpotifyAPI(cache_path=None)
-    api.handler = RequestHandler(name=api.source, token=token, cache_path=None)
+    api = SpotifyAPI(token=token)
+    # blocks any token tests
+    api.handler.authoriser.test_args = None
+    api.handler.authoriser.test_expiry = 0
+    api.handler.authoriser.test_condition = None
     with api as a:
         yield a
 

--- a/tests/core/base.py
+++ b/tests/core/base.py
@@ -12,7 +12,7 @@ class MusifyItemTester(PrettyPrinterTester, metaclass=ABCMeta):
 
     @abstractmethod
     def item(self, *args, **kwargs) -> MusifyItem:
-        """Yields an :py:class:`MusifyItem` object to be tested as pytest.fixture"""
+        """Yields an :py:class:`MusifyItem` object to be tested as pytest.fixture."""
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/core/printer.py
+++ b/tests/core/printer.py
@@ -11,7 +11,7 @@ class PrettyPrinterTester(ABC):
 
     @abstractmethod
     def obj(self, *args, **kwargs) -> PrettyPrinter:
-        """Yields a :py:class:`PrettyPrinter` object to be tested as pytest.fixture"""
+        """Yields a :py:class:`PrettyPrinter` object to be tested as pytest.fixture."""
         raise NotImplementedError
 
     @staticmethod

--- a/tests/libraries/core/collection.py
+++ b/tests/libraries/core/collection.py
@@ -29,7 +29,7 @@ class MusifyCollectionTester(PrettyPrinterTester, metaclass=ABCMeta):
 
     @abstractmethod
     def collection(self, *args, **kwargs) -> MusifyCollection:
-        """Yields an :py:class:`MusifyCollection` object to be tested as pytest.fixture"""
+        """Yields an :py:class:`MusifyCollection` object to be tested as pytest.fixture."""
         raise NotImplementedError
 
     @abstractmethod
@@ -214,7 +214,7 @@ class PlaylistTester(MusifyCollectionTester, metaclass=ABCMeta):
 
     @abstractmethod
     def playlist(self, *args, **kwargs) -> Playlist:
-        """Yields an :py:class:`Playlist` object to be tested as pytest.fixture"""
+        """Yields an :py:class:`Playlist` object to be tested as pytest.fixture."""
         raise NotImplementedError
 
     @pytest.fixture
@@ -299,7 +299,7 @@ class LibraryTester(MusifyCollectionTester, metaclass=ABCMeta):
 
     @abstractmethod
     def library(self, *args, **kwargs) -> Library:
-        """Yields a loaded :py:class:`Library` object to be tested as pytest.fixture"""
+        """Yields a loaded :py:class:`Library` object to be tested as pytest.fixture."""
         raise NotImplementedError
 
     @pytest.fixture

--- a/tests/libraries/local/playlist/test_m3u.py
+++ b/tests/libraries/local/playlist/test_m3u.py
@@ -160,10 +160,7 @@ class TestM3U(LocalPlaylistTester):
         assert result.difference == 5
         assert result.final == 35
 
-        if not os.getenv("GITHUB_ACTIONS"):
-            # TODO: these assertions always fail on GitHub actions but not locally, why?
-            assert pl.date_modified > original_dt_modified
-            assert pl.date_created == original_dt_created
+        assert pl.date_modified > original_dt_modified
 
         with open(path_new, 'r') as f:
             paths = [line.strip() for line in f]
@@ -202,11 +199,8 @@ class TestM3U(LocalPlaylistTester):
         assert result.difference == 9
         assert result.final == 12
 
-        if not os.getenv("GITHUB_ACTIONS"):
-            # TODO: these assertions always fail on GitHub actions but not locally, why?
-            assert pl.date_modified > original_dt_modified
-            assert pl.date_created == original_dt_created
         new_dt_modified = pl.date_modified
+        assert new_dt_modified > original_dt_modified
 
         # assert file has reported path count and paths in the file have been mapped to relative paths
         with open(path, "r") as f:
@@ -220,10 +214,8 @@ class TestM3U(LocalPlaylistTester):
         assert pl.path == join(tmp_path, "New Playlist" + pl.ext)
         pl.save(dry_run=False)
 
-        if not os.getenv("GITHUB_ACTIONS"):
-            # TODO: these assertions always fail on GitHub actions but not locally, why?
-            assert pl.date_modified > new_dt_modified
-            assert pl.date_created > original_dt_created
+        assert pl.date_modified > new_dt_modified
+        assert pl.date_created > original_dt_created
 
         with open(pl.path, 'r') as f:
             paths = [line.strip() for line in f]

--- a/tests/libraries/local/playlist/test_m3u.py
+++ b/tests/libraries/local/playlist/test_m3u.py
@@ -1,4 +1,3 @@
-import os
 from os.path import join, splitext, basename, exists
 from pathlib import Path
 from random import randrange
@@ -146,7 +145,6 @@ class TestM3U(LocalPlaylistTester):
         assert paths == [track.path for track in pl.tracks]
 
         original_dt_modified = pl.date_modified
-        original_dt_created = pl.date_created
 
         # ...remove some tracks and add some new ones
         tracks_random_new = random_tracks(15)

--- a/tests/libraries/local/playlist/test_xautopf.py
+++ b/tests/libraries/local/playlist/test_xautopf.py
@@ -588,7 +588,6 @@ class TestXMLPlaylistParser(PrettyPrinterTester):
         assert actual_weight == parser_final.xml_smart_playlist["@ShuffleSameArtistWeight"]
 
 
-@pytest.mark.manual
 @pytest.fixture(scope="module")
 def library() -> LocalLibrary:
     """Yields a loaded :py:class:`LocalLibrary` to supply tracks for manual checking of custom playlist files"""

--- a/tests/libraries/local/playlist/test_xautopf.py
+++ b/tests/libraries/local/playlist/test_xautopf.py
@@ -609,11 +609,8 @@ def library() -> LocalLibrary:
     reason="Only runs when the test or marker is specified explicitly by the user",
 )
 @pytest.mark.parametrize("source,expected", [
-    (
-        join(os.getenv("TEST_PL_SOURCE", ""), f"{splitext(basename(name))[0]}.xautopf"),
-        join(os.getenv("TEST_PL_COMPARISON", ""), f"{splitext(basename(name))[0]}.m3u"),
-    )
-    for name in glob(join(os.getenv("TEST_PL_SOURCE", ""), "**", "*.xautopf"), recursive=True)
+    (path, join(os.getenv("TEST_PL_COMPARISON", ""), f"{splitext(basename(path))[0]}.m3u"))
+    for path in glob(join(os.getenv("TEST_PL_SOURCE", path_txt), "**", "*.xautopf"), recursive=True)
 ])
 def test_playlist_paths_manual(library: LocalLibrary, source: str, expected: str):
     assert exists(source)

--- a/tests/libraries/local/playlist/test_xautopf.py
+++ b/tests/libraries/local/playlist/test_xautopf.py
@@ -204,11 +204,7 @@ class TestXAutoPF(LocalPlaylistTester):
         pl.description = "new description"
         pl.save(dry_run=False)
 
-        if not os.getenv("GITHUB_ACTIONS"):
-            # TODO: these assertions always fail on GitHub actions but not locally, why?
-            assert pl.date_modified > original_dt_modified
-            assert pl.date_created == original_dt_created
-
+        assert pl.date_modified > original_dt_modified
         assert pl._parser.xml != original_parser
         assert pl._parser.xml_smart_playlist["@GroupBy"] == original_parser.xml_smart_playlist["@GroupBy"]
         assert pl._parser.xml_source["Conditions"] == original_parser.xml_source["Conditions"]

--- a/tests/libraries/local/playlist/test_xautopf.py
+++ b/tests/libraries/local/playlist/test_xautopf.py
@@ -605,7 +605,7 @@ def library() -> LocalLibrary:
 )
 @pytest.mark.parametrize("source,expected", [
     (path, join(os.getenv("TEST_PL_COMPARISON", ""), f"{splitext(basename(path))[0]}.m3u"))
-    for path in glob(join(os.getenv("TEST_PL_SOURCE", path_txt), "**", "*.xautopf"), recursive=True)
+    for path in glob(join(os.getenv("TEST_PL_SOURCE", ""), "**", "*.xautopf"), recursive=True)
 ])
 def test_playlist_paths_manual(library: LocalLibrary, source: str, expected: str):
     assert exists(source)

--- a/tests/libraries/local/test_collection.py
+++ b/tests/libraries/local/test_collection.py
@@ -23,7 +23,7 @@ class TestLocalFolder(LocalCollectionTester):
 
     @pytest.fixture
     def folder(self, tracks: list[LocalTrack]) -> LocalFolder:
-        """Yields a :py:class:`LocalFolder` object to be tested as pytest.fixture"""
+        """Yields a :py:class:`LocalFolder` object to be tested as pytest.fixture."""
         return LocalFolder(tracks=[copy(track) for track in tracks if track.folder == self.name])
 
     @pytest.fixture(scope="class")
@@ -89,7 +89,7 @@ class TestLocalAlbum(LocalCollectionTester):
 
     @pytest.fixture
     def album(self, tracks: list[LocalTrack]) -> LocalAlbum:
-        """Yields a :py:class:`LocalAlbum` object to be tested as pytest.fixture"""
+        """Yields a :py:class:`LocalAlbum` object to be tested as pytest.fixture."""
         return LocalAlbum(tracks=[copy(track) for track in tracks], name=self.name)
 
     @pytest.fixture(scope="class")
@@ -156,7 +156,7 @@ class TestLocalArtist(LocalCollectionTester):
 
     @pytest.fixture
     def artist(self, tracks: list[LocalTrack]) -> LocalArtist:
-        """Yields a :py:class:`LocalArtist` object to be tested as pytest.fixture"""
+        """Yields a :py:class:`LocalArtist` object to be tested as pytest.fixture."""
         return LocalArtist(tracks=[copy(track) for track in tracks], name=self.name)
 
     @pytest.fixture(scope="class")
@@ -218,7 +218,7 @@ class TestLocalGenres(LocalCollectionTester):
 
     @pytest.fixture
     def genre(self, tracks: list[LocalTrack]) -> LocalGenres:
-        """Yields a :py:class:`LocalGenres` object to be tested as pytest.fixture"""
+        """Yields a :py:class:`LocalGenres` object to be tested as pytest.fixture."""
         return LocalGenres(tracks=[copy(track) for track in tracks], name=self.name)
 
     @pytest.fixture(scope="class")

--- a/tests/libraries/local/track/test_track.py
+++ b/tests/libraries/local/track/test_track.py
@@ -242,15 +242,18 @@ class TestLocalTrack(MusifyItemTester):
         track_from_file = track.__class__(file=track._reader.file)
         assert id(track._reader.file) == id(track_from_file._reader.file)
 
+        keys = [key for key in track.__slots__ if key.lstrip("_") in dir(track)]
+
         track_copy = copy(track)
         assert id(track._reader.file) == id(track_copy._reader.file)
-        for key, value in vars(track).items():
-            assert value == track_copy[key]
+        for key in keys:
+            print(key)
+            assert getattr(track, key) == getattr(track_copy, key)
 
         track_deepcopy = deepcopy(track)
         assert id(track._reader.file) != id(track_deepcopy._reader.file)
-        for key, value in vars(track).items():
-            assert value == track_deepcopy[key]
+        for key in keys:
+            assert getattr(track, key) == getattr(track_deepcopy, key)
 
     def test_set_and_find_file_paths(self, track: LocalTrack, tmp_path: Path):
         paths = track.__class__.get_filepaths(str(tmp_path))

--- a/tests/libraries/local/track/test_track.py
+++ b/tests/libraries/local/track/test_track.py
@@ -247,7 +247,6 @@ class TestLocalTrack(MusifyItemTester):
         track_copy = copy(track)
         assert id(track._reader.file) == id(track_copy._reader.file)
         for key in keys:
-            print(key)
             assert getattr(track, key) == getattr(track_copy, key)
 
         track_deepcopy = deepcopy(track)

--- a/tests/libraries/local/track/utils.py
+++ b/tests/libraries/local/track/utils.py
@@ -31,15 +31,12 @@ def random_track[T: LocalTrack](cls: type[T] | None = None) -> T:
     """Generates a new, random track of the given class."""
     if cls is None:
         cls = choice(tuple(TRACK_CLASSES))
-    track = cls.__new__(cls)
-    super(LocalTrack, track).__init__()
 
     file = MutagenMock()
     file.info.length = randint(30, 600)
 
-    track._reader = track._create_reader(file=file, tag_map=track.tag_map, remote_wrangler=remote_wrangler)
-    track._writer = track._create_writer(file=file, tag_map=track.tag_map, remote_wrangler=remote_wrangler)
-
+    cls._load = False
+    track = cls(file=file, remote_wrangler=remote_wrangler)
     track._loaded = True
 
     track.title = random_str(30, 50)
@@ -71,6 +68,7 @@ def random_track[T: LocalTrack](cls: type[T] | None = None) -> T:
     track.play_count = randrange(200)
     track.rating = randrange(0, 100)
 
+    cls._load = True
     return track
 
 

--- a/tests/libraries/local/track/utils.py
+++ b/tests/libraries/local/track/utils.py
@@ -34,15 +34,11 @@ def random_track[T: LocalTrack](cls: type[T] | None = None) -> T:
     track = cls.__new__(cls)
     super(LocalTrack, track).__init__()
 
-    track._available_paths = set()
-    track._available_paths_lower = set()
-
     file = MutagenMock()
     file.info.length = randint(30, 600)
 
     track._reader = track._create_reader(file=file, tag_map=track.tag_map, remote_wrangler=remote_wrangler)
     track._writer = track._create_writer(file=file, tag_map=track.tag_map, remote_wrangler=remote_wrangler)
-    track.remote_wrangler = remote_wrangler
 
     track._loaded = True
 

--- a/tests/libraries/remote/core/api.py
+++ b/tests/libraries/remote/core/api.py
@@ -25,12 +25,12 @@ class RemoteAPITester(ABC):
 
     @abstractmethod
     def object_factory(self) -> RemoteObjectFactory:
-        """Yield the object factory for objects of this remote service type as a pytest.fixture"""
+        """Yield the object factory for objects of this remote service type as a pytest.fixture."""
         raise NotImplementedError
 
     @pytest.fixture
     def _responses(self, object_type: RemoteObjectType, api_mock: RemoteMock) -> dict[str, dict[str, Any]]:
-        """Yields valid responses mapped by ID for a given ``object_type`` as a pytest.fixture"""
+        """Yields valid responses mapped by ID for a given ``object_type`` as a pytest.fixture."""
         source = api_mock.item_type_map[object_type]
         if len(source) > api_mock.limit_lower:
             source = sample(source, k=api_mock.limit_lower)
@@ -48,7 +48,7 @@ class RemoteAPITester(ABC):
 
     @pytest.fixture
     def response(self, responses: dict[str, dict[str, Any]]) -> dict[str, Any]:
-        """Yields a random valid response from a given set of ``responses`` as a pytest.fixture"""
+        """Yields a random valid response from a given set of ``responses`` as a pytest.fixture."""
         return choice(list(responses.values()))
 
     @pytest.fixture

--- a/tests/libraries/remote/core/processors/check.py
+++ b/tests/libraries/remote/core/processors/check.py
@@ -50,7 +50,7 @@ class RemoteItemCheckerTester(PrettyPrinterTester, metaclass=ABCMeta):
     ) -> tuple[RemotePlaylist, BasicCollection]:
         """Setups up checker, playlist, and collection for testing match_to_remote functionality"""
         url = choice(playlist_urls)
-        pl = checker.factory.playlist(checker.api.get_items(url, extend=True, use_cache=False)[0])
+        pl = checker.factory.playlist(checker.api.get_items(url, extend=True)[0])
         assert len(pl) > 10
         assert len({item.uri for item in pl}) == len(pl)  # all unique tracks
 
@@ -71,8 +71,8 @@ class RemoteItemCheckerTester(PrettyPrinterTester, metaclass=ABCMeta):
     @staticmethod
     def test_make_temp_playlist(checker: RemoteItemChecker, api_mock: RemoteMock, token_file_path: str):
         # force auth test to fail and reload from token
-        checker.api.handler.token = None
-        checker.api.handler.token_file_path = token_file_path
+        checker.api.handler.authoriser.token = None
+        checker.api.handler.authoriser.token_file_path = token_file_path
 
         collection = BasicCollection(name=random_str(30, 50), items=random_tracks())
         for item in collection:
@@ -88,7 +88,7 @@ class RemoteItemCheckerTester(PrettyPrinterTester, metaclass=ABCMeta):
             item.uri = random_uri()
 
         checker._create_playlist(collection=collection)
-        assert checker.api.handler.token is not None
+        assert checker.api.handler.authoriser.token is not None
         assert collection.name in checker._playlist_name_urls
         assert checker._playlist_name_collection[collection.name] == collection
         assert len(api_mock.request_history) >= 2
@@ -102,14 +102,14 @@ class RemoteItemCheckerTester(PrettyPrinterTester, metaclass=ABCMeta):
             token_file_path: str
     ):
         # force auth test to fail and reload from token
-        checker.api.handler.token = None
-        checker.api.handler.token_file_path = token_file_path
+        checker.api.handler.authoriser.token = None
+        checker.api.handler.authoriser.token_file_path = token_file_path
 
         checker._playlist_name_urls = {collection.name: url for collection, url in zip(collections, playlist_urls)}
         checker._playlist_name_collection = {collection.name: collection for collection in collections}
 
         checker._delete_playlists()
-        assert checker.api.handler.token is not None
+        assert checker.api.handler.authoriser.token is not None
         assert not checker._playlist_name_urls
         assert not checker._playlist_name_collection
         assert len(api_mock.get_requests(method="DELETE")) == min(len(playlist_urls), len(collections))

--- a/tests/libraries/remote/core/processors/check.py
+++ b/tests/libraries/remote/core/processors/check.py
@@ -553,13 +553,13 @@ class RemoteItemCheckerTester(PrettyPrinterTester, metaclass=ABCMeta):
             mocker: MockerFixture,
             api_mock: RemoteMock,
     ):
-        def add_collection(collection: BasicCollection):
+        def add_collection(self, collection: BasicCollection):
             """Just simply add the collection and associated URL to the ItemChecker without calling API"""
-            checker._playlist_name_urls[collection.name] = playlist_name_urls[collection.name]
-            checker._playlist_name_collection[collection.name] = collection
+            self._playlist_name_urls[collection.name] = playlist_name_urls[collection.name]
+            self._playlist_name_collection[collection.name] = collection
 
         playlist_name_urls = {collection.name: url for collection, url in zip(collections, playlist_urls)}
-        mocker.patch.object(checker, "_create_playlist", new=add_collection)
+        mocker.patch.object(RemoteItemChecker, "_create_playlist", new=add_collection)
 
         interval = len(collections) // 3
         checker.interval = interval

--- a/tests/libraries/remote/core/processors/check.py
+++ b/tests/libraries/remote/core/processors/check.py
@@ -29,17 +29,17 @@ class RemoteItemCheckerTester(PrettyPrinterTester, metaclass=ABCMeta):
 
     @abstractmethod
     def checker(self, *args, **kwargs) -> RemoteItemChecker:
-        """Yields a valid :py:class:`RemoteItemChecker` for the current remote source as a pytest.fixture"""
+        """Yields a valid :py:class:`RemoteItemChecker` for the current remote source as a pytest.fixture."""
         raise NotImplementedError
 
     @abstractmethod
     def playlist_urls(self, *args, **kwargs) -> list[str]:
-        """Yields a list of URLs that will return valid responses from the api_mock as a pytest.fixture"""
+        """Yields a list of URLs that will return valid responses from the api_mock as a pytest.fixture."""
         raise NotImplementedError
 
     @pytest.fixture
     def collections(self, playlist_urls: list[str]) -> list[BasicCollection]:
-        """Yields many valid :py:class:`BasicCollection` of :py:class:`LocalTrack` as a pytest.fixture"""
+        """Yields many valid :py:class:`BasicCollection` of :py:class:`LocalTrack` as a pytest.fixture."""
         count = randrange(6, len(playlist_urls))
         return [BasicCollection(name=random_str(30, 50), items=random_tracks()) for _ in range(count)]
 

--- a/tests/libraries/remote/core/processors/search.py
+++ b/tests/libraries/remote/core/processors/search.py
@@ -28,7 +28,7 @@ class RemoteItemSearcherTester(PrettyPrinterTester, metaclass=ABCMeta):
 
     @abstractmethod
     def searcher(self, *args, **kwargs) -> RemoteItemSearcher:
-        """Yields a valid :py:class:`RemoteItemSearcher` for the current remote source as a pytest.fixture"""
+        """Yields a valid :py:class:`RemoteItemSearcher` for the current remote source as a pytest.fixture."""
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/libraries/remote/core/processors/search.py
+++ b/tests/libraries/remote/core/processors/search.py
@@ -179,6 +179,7 @@ class RemoteItemSearcherTester(PrettyPrinterTester, metaclass=ABCMeta):
     ###########################################################################
     ## _search_collection tests
     ###########################################################################
+    # noinspection PyProtectedMember
     @staticmethod
     @pytest.fixture
     def search_album(search_albums: list[LocalAlbum]):
@@ -188,7 +189,7 @@ class RemoteItemSearcherTester(PrettyPrinterTester, metaclass=ABCMeta):
 
         skip = 0
         for skip, item in enumerate(collection[:len(collection) // 2], 1):
-            item.uri = item.remote_wrangler.unavailable_uri_dummy
+            item.uri = item._reader.remote_wrangler.unavailable_uri_dummy
             assert item.has_uri is False
         assert skip > 0  # check test input is valid
 

--- a/tests/libraries/remote/spotify/api/mock.py
+++ b/tests/libraries/remote/spotify/api/mock.py
@@ -237,8 +237,10 @@ class SpotifyMock(RemoteMock):
     ###########################################################################
     def setup_requests_mock(self):
         """Driver to setup requests_mock responses for all endpoints"""
+        url_api = SpotifyDataWrangler.url_api
+
         self.setup_search_mock()
-        self.get(url=f"{SpotifyDataWrangler.url_api}/me", json=lambda _, __: deepcopy(self.user))
+        self.get(url=f"{url_api}/me", json=lambda _, __: deepcopy(self.user))
 
         # setup responses as needed for each item type
         self.setup_items_mock(kind=ObjectType.TRACK, id_map={item["id"]: item for item in self.tracks})
@@ -277,7 +279,7 @@ class SpotifyMock(RemoteMock):
         for i, artist in enumerate(self.artists):
             id_ = artist["id"]
             items = [album for album in self.artist_albums if any(art["id"] == id_ for art in album["artists"])]
-            url = f"{SpotifyDataWrangler.url_api}/artists/{id_}/albums"
+            url = f"{url_api}/artists/{id_}/albums"
             self.setup_items_block_mock(url=url, items=items)
 
         # when getting a user's playlists, individual tracks are not returned
@@ -286,7 +288,6 @@ class SpotifyMock(RemoteMock):
             playlist["tracks"] = {"href": playlist["tracks"]["href"], "total": playlist["tracks"]["total"]}
 
         # setup responses as needed for each 'user's saved' type
-        url_api = SpotifyDataWrangler.url_api
         self.setup_items_block_mock(url=f"{url_api}/me/tracks", items=self.user_tracks)
         self.setup_items_block_mock(url=f"{url_api}/me/following", items=self.user_artists)
         self.setup_items_block_mock(url=f"{url_api}/me/episodes", items=self.user_episodes)
@@ -356,8 +357,8 @@ class SpotifyMock(RemoteMock):
             id_list = req_params["ids"][0].split(",")
             return {req_kind: [deepcopy(id_map[i]) for i in id_list]}
 
-        url_base = SpotifyDataWrangler.url_api
-        url = f"{url_base}/{kind.name.lower()}s" if isinstance(kind, ObjectType) else f"{url_base}/{kind}"
+        url_api = SpotifyDataWrangler.url_api
+        url = f"{url_api}/{kind.name.lower()}s" if isinstance(kind, ObjectType) else f"{url_api}/{kind}"
         if batchable:
             self.get(url=re.compile(url + r"\?"), json=response_getter)  # item batched calls
 

--- a/tests/libraries/remote/spotify/api/test_api.py
+++ b/tests/libraries/remote/spotify/api/test_api.py
@@ -39,8 +39,16 @@ class TestSpotifyAPI:
     def test_init_cache(self, cache: ResponseCache):
         SpotifyAPI(cache=cache)
 
-        expected_names_normal = ["tracks", "artists", "albums", "audio_features", "audio_analysis"]
-        expected_names_paginated = ["artist_albums", "album_tracks"]
+        expected_names_normal = [
+            "tracks",
+            "audio_features",
+            "audio_analysis",
+            "albums",
+            "artists",
+            "episodes",
+            "chapters",
+        ]
+        expected_names_paginated = ["album_tracks", "artist_albums", "show_episodes", "audiobook_chapters"]
 
         assert all(name in cache for name in expected_names_normal)
         assert all(name in cache for name in expected_names_paginated)

--- a/tests/libraries/remote/spotify/api/test_api.py
+++ b/tests/libraries/remote/spotify/api/test_api.py
@@ -1,15 +1,77 @@
 import pytest
 
+from musify.api.cache.backend.base import ResponseCache, PaginatedRequestSettings
+from musify.api.cache.backend.sqlite import SQLiteCache
+from musify.libraries.remote.spotify.api import SpotifyAPI
+from tests.libraries.remote.spotify.utils import random_id
+from tests.utils import random_str
+
 
 class TestSpotifyAPI:
-    @pytest.mark.skip(reason="Not yet implemented")
-    def test_init_authoriser(self):
-        pass  # TODO
 
-    @pytest.mark.skip(reason="Not yet implemented")
-    def test_init_cache(self):
-        pass  # TODO
+    @pytest.fixture
+    def cache(self) -> ResponseCache:
+        """Yields a valid :py:class:`ResponseCache` to use throughout tests in this suite as a pytest.fixture."""
+        return SQLiteCache.connect_with_in_memory_db()
 
-    @pytest.mark.skip(reason="Not yet implemented")
-    def test_cache_repository_getter(self):
-        pass  # TODO
+    def test_init_authoriser(self, cache: ResponseCache):
+        client_id = "CLIENT_ID"
+        client_secret = "CLIENT_SECRET"
+        scopes = ["scope 1", "scope 2"]
+        token_file_path = "i am a path to a file.json"
+
+        api = SpotifyAPI(
+            client_id=client_id,
+            client_secret=client_secret,
+            scopes=scopes,
+            cache=cache,
+            token_file_path=token_file_path,
+            name="this name won't be used",
+        )
+
+        assert api.handler.authoriser.name == api.wrangler.source
+        assert api.handler.authoriser.user_args["params"]["client_id"] == client_id
+        assert api.handler.authoriser.user_args["params"]["scope"] == " ".join(scopes)
+        assert api.handler.authoriser.token_file_path == token_file_path
+
+        assert api.handler.cache.cache_name == cache.cache_name
+
+    def test_init_cache(self, cache: ResponseCache):
+        SpotifyAPI(cache=cache)
+
+        expected_names_normal = ["tracks", "artists", "albums", "playlists", "audio_features", "audio_analysis"]
+        expected_names_paginated = ["artist_albums", "album_tracks", "playlist_tracks"]
+
+        assert all(name in cache for name in expected_names_normal)
+        assert all(name in cache for name in expected_names_paginated)
+
+        assert all(not isinstance(cache[name].settings, PaginatedRequestSettings) for name in expected_names_normal)
+        assert all(isinstance(cache[name].settings, PaginatedRequestSettings) for name in expected_names_paginated)
+
+    def test_init_cache_repository_getter(self, cache: ResponseCache):
+        api = SpotifyAPI(cache=cache)
+
+        name_url_map = {
+            "tracks": f"{api.wrangler.url_api}/tracks/{random_id()}",
+            "artists": f"{api.wrangler.url_api}/artists?ids={",".join(random_id() for _ in range(10))}",
+            "albums": f"{api.wrangler.url_api}/albums?ids={",".join(random_id() for _ in range(50))}",
+            "playlists": f"{api.wrangler.url_api}/playlists",
+        }
+        names_paginated = ["artist_albums", "album_tracks", "playlist_tracks"]
+        for name in names_paginated:
+            parent, child = name.split("_")
+            parent = parent.rstrip("s") + "s"
+            child = child.rstrip("s") + "s"
+
+            url = f"{api.wrangler.url_api}/{parent}/{random_id()}/{child}"
+            name_url_map[name] = url
+
+        for name, url in name_url_map.items():
+            repository = cache.get_repository_from_url(url)
+            assert repository.settings.name == name
+
+        # un-cached URLs
+        assert cache.get_repository_from_url(f"{api.wrangler.url_api}/me/albums") is None
+        assert cache.get_repository_from_url(f"{api.wrangler.url_api}/search") is None
+        assert cache.get_repository_from_url(f"{api.wrangler.url_api}/playlists/{random_id()}/followers") is None
+        assert cache.get_repository_from_url(f"{api.wrangler.url_api}/users/{random_str(10, 30)}/playlists") is None

--- a/tests/libraries/remote/spotify/api/test_api.py
+++ b/tests/libraries/remote/spotify/api/test_api.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+class TestSpotifyAPI:
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_init_authoriser(self):
+        pass  # TODO
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_init_cache(self):
+        pass  # TODO

--- a/tests/libraries/remote/spotify/api/test_api.py
+++ b/tests/libraries/remote/spotify/api/test_api.py
@@ -9,3 +9,7 @@ class TestSpotifyAPI:
     @pytest.mark.skip(reason="Not yet implemented")
     def test_init_cache(self):
         pass  # TODO
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_cache_repository_getter(self):
+        pass  # TODO

--- a/tests/libraries/remote/spotify/api/test_api.py
+++ b/tests/libraries/remote/spotify/api/test_api.py
@@ -39,8 +39,8 @@ class TestSpotifyAPI:
     def test_init_cache(self, cache: ResponseCache):
         SpotifyAPI(cache=cache)
 
-        expected_names_normal = ["tracks", "artists", "albums", "playlists", "audio_features", "audio_analysis"]
-        expected_names_paginated = ["artist_albums", "album_tracks", "playlist_tracks"]
+        expected_names_normal = ["tracks", "artists", "albums", "audio_features", "audio_analysis"]
+        expected_names_paginated = ["artist_albums", "album_tracks"]
 
         assert all(name in cache for name in expected_names_normal)
         assert all(name in cache for name in expected_names_paginated)
@@ -55,9 +55,8 @@ class TestSpotifyAPI:
             "tracks": f"{api.wrangler.url_api}/tracks/{random_id()}",
             "artists": f"{api.wrangler.url_api}/artists?ids={",".join(random_id() for _ in range(10))}",
             "albums": f"{api.wrangler.url_api}/albums?ids={",".join(random_id() for _ in range(50))}",
-            "playlists": f"{api.wrangler.url_api}/playlists",
         }
-        names_paginated = ["artist_albums", "album_tracks", "playlist_tracks"]
+        names_paginated = ["artist_albums", "album_tracks"]
         for name in names_paginated:
             parent, child = name.split("_")
             parent = parent.rstrip("s") + "s"

--- a/tests/libraries/remote/spotify/api/test_artist.py
+++ b/tests/libraries/remote/spotify/api/test_artist.py
@@ -19,7 +19,7 @@ class TestSpotifyAPIArtists:
 
     @pytest.fixture
     def artist_album_types(self) -> tuple[str, ...]:
-        """Yields the artist album types to get for a given artist as a pytest.fixture"""
+        """Yields the artist album types to get for a given artist as a pytest.fixture."""
         return tuple(sample(sorted(ARTIST_ALBUM_TYPES), k=randrange(2, len(ARTIST_ALBUM_TYPES))))
 
     # noinspection PyTestUnpassedFixture
@@ -46,7 +46,7 @@ class TestSpotifyAPIArtists:
     def artist_albums(
             self, artist: dict[str, Any], artists_albums: dict[str, list[dict[str, Any]]]
     ) -> list[dict[str, Any]]:
-        """Yields the albums for a given ``artist`` as a pytest.fixture"""
+        """Yields the albums for a given ``artist`` as a pytest.fixture."""
         return deepcopy(artists_albums[artist["id"]])
 
     # noinspection PyTestUnpassedFixture
@@ -60,7 +60,7 @@ class TestSpotifyAPIArtists:
 
     @pytest.fixture
     def artist(self, artists: dict[Any, dict[str, Any]]) -> dict[str, Any]:
-        """Yields a randomly selected artist from a given set of ``artists`` as a pytest.fixture"""
+        """Yields a randomly selected artist from a given set of ``artists`` as a pytest.fixture."""
         return choice(list(artists.values()))
 
     @staticmethod

--- a/tests/libraries/remote/spotify/api/test_cache.py
+++ b/tests/libraries/remote/spotify/api/test_cache.py
@@ -1,0 +1,50 @@
+from random import choice
+
+import pytest
+
+from musify.libraries.remote.spotify.api import SpotifyAPI
+from musify.libraries.remote.spotify.api.cache import SpotifyRequestSettings, SpotifyPaginatedRequestSettings
+from musify.libraries.remote.spotify.processors import SpotifyDataWrangler
+from tests.libraries.remote.spotify.api.mock import SpotifyMock
+
+
+class TestSpotifyRequestSettings:
+
+    @pytest.fixture(scope="class")
+    def settings(self) -> SpotifyRequestSettings:
+        """Yields a :py:class:`SpotifyRequestSettings` object as a pytest.fixture."""
+        return SpotifyRequestSettings(name="test")
+
+    def test_core_getters(self, settings: SpotifyRequestSettings, api_mock: SpotifyMock):
+        for responses in api_mock.item_type_map.values():
+            response = choice(responses)
+            name = response["display_name"] if response["type"] == "user" else response["name"]
+            assert settings.get_name(response) == name
+            assert settings.get_id(response["href"]) == response["id"]
+
+        response = choice(api_mock.user_tracks)
+        assert settings.get_name(response) is None
+
+        url = f"{SpotifyDataWrangler.url_api}/me/tracks"
+        assert settings.get_id(url) is None
+
+    @pytest.fixture(scope="class")
+    def settings_paginated(self) -> SpotifyPaginatedRequestSettings:
+        """Yields a :py:class:`SpotifyPaginatedRequestSettings` object as a pytest.fixture."""
+        return SpotifyPaginatedRequestSettings(name="test")
+
+    def test_paginated_getters(
+            self,
+            settings_paginated: SpotifyPaginatedRequestSettings,
+            api: SpotifyAPI,
+            api_mock: SpotifyMock
+    ):
+        for parent, child in api.collection_item_map.items():
+            response = choice(api_mock.item_type_map[parent])[child.name.lower() + "s"]
+            url = response["href"]
+            assert settings_paginated.get_offset(url) == response["offset"]
+            assert settings_paginated.get_limit(url) == response["limit"]
+
+        url = f"{SpotifyDataWrangler.url_api}/me/tracks"
+        assert settings_paginated.get_offset(url) == 0
+        assert settings_paginated.get_limit(url) == 50

--- a/tests/libraries/remote/spotify/api/test_item.py
+++ b/tests/libraries/remote/spotify/api/test_item.py
@@ -30,7 +30,7 @@ class TestSpotifyAPIItems(RemoteAPITester):
 
     @pytest.fixture(scope="class")
     def object_factory(self) -> SpotifyObjectFactory:
-        """Yield the object factory for Spotify objects as a pytest.fixture"""
+        """Yield the object factory for Spotify objects as a pytest.fixture."""
         return SpotifyObjectFactory()
 
     @pytest.fixture
@@ -244,9 +244,19 @@ class TestSpotifyAPIItems(RemoteAPITester):
             api.get_artist_albums(values=random_id(), types=("unknown", "invalid"))
 
     ###########################################################################
-    ## Multi-, Batched-, and Extend tests for each supported item type
+    ## Cached-, Multi-, Batched-, and Extend tests for each supported item type
     ###########################################################################
-    def test_get_item_multi(
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_get_items_from_cache(
+            self,
+            object_type: RemoteObjectType,
+            responses: dict[str, dict[str, Any]],
+            api: SpotifyAPI,
+            api_mock: SpotifyMock
+    ):
+        pass  # TODO
+
+    def test_get_items_multi(
             self,
             object_type: RemoteObjectType,
             responses: dict[str, dict[str, Any]],
@@ -276,7 +286,7 @@ class TestSpotifyAPIItems(RemoteAPITester):
         RemoteObjectType.AUDIOBOOK,
         RemoteObjectType.CHAPTER,
     ], ids=idfn)
-    def test_get_item_batched(
+    def test_get_items_batched(
             self,
             object_type: RemoteObjectType,
             responses: dict[str, dict[str, Any]],
@@ -587,27 +597,27 @@ class TestSpotifyAPIItems(RemoteAPITester):
     ###########################################################################
     @pytest.fixture
     def features_all(self, responses: dict[str, dict[str, Any]], api_mock: SpotifyMock) -> dict[str, dict[str, Any]]:
-        """Yield all audio features responses for the given ``responses`` as a pytest.fixture"""
+        """Yield all audio features responses for the given ``responses`` as a pytest.fixture."""
         for response in responses:
             assert "audio_features" not in response
         return {id_: deepcopy(api_mock.audio_features[id_]) for id_ in responses if id_ in api_mock.audio_features}
 
     @pytest.fixture
     def features(self, response: dict[str, Any], features_all: dict[str, dict[str, Any]]) -> dict[str, Any]:
-        """Yield the audio features  response for the given ``response`` as a pytest.fixture"""
+        """Yield the audio features  response for the given ``response`` as a pytest.fixture."""
         assert "audio_features" not in response
         return features_all[response[self.id_key]]
 
     @pytest.fixture
     def analysis_all(self, responses: dict[str, dict[str, Any]], api_mock: SpotifyMock) -> dict[str, dict[str, Any]]:
-        """Yield all audio analyses responses for the given ``responses`` as a pytest.fixture"""
+        """Yield all audio analyses responses for the given ``responses`` as a pytest.fixture."""
         for response in responses:
             assert "audio_analysis" not in response
         return {id_: deepcopy(api_mock.audio_analysis[id_]) for id_ in responses if id_ in api_mock.audio_analysis}
 
     @pytest.fixture
     def analysis(self, response: dict[str, Any], analysis_all: dict[str, dict[str, Any]]) -> dict[str, Any]:
-        """Yield all audio analysis response for the given ``response`` as a pytest.fixture"""
+        """Yield all audio analysis response for the given ``response`` as a pytest.fixture."""
         assert "audio_analysis" not in response
         return analysis_all[response[self.id_key]]
 

--- a/tests/libraries/remote/spotify/api/test_item.py
+++ b/tests/libraries/remote/spotify/api/test_item.py
@@ -255,11 +255,8 @@ class TestSpotifyAPIItems(RemoteAPITester):
 
     # noinspection PyTestUnpassedFixture
     @pytest.mark.parametrize("object_type", [
+        RemoteObjectType.PLAYLIST,
         RemoteObjectType.USER,
-        RemoteObjectType.SHOW,
-        RemoteObjectType.EPISODE,
-        RemoteObjectType.AUDIOBOOK,
-        RemoteObjectType.CHAPTER,
     ], ids=idfn)
     def test_get_items_from_cache_skips(
             self,
@@ -284,6 +281,10 @@ class TestSpotifyAPIItems(RemoteAPITester):
         RemoteObjectType.TRACK,
         RemoteObjectType.ALBUM,
         RemoteObjectType.ARTIST,
+        RemoteObjectType.SHOW,
+        RemoteObjectType.EPISODE,
+        RemoteObjectType.AUDIOBOOK,
+        RemoteObjectType.CHAPTER,
     ], ids=idfn)
     def test_get_items_from_cache(
             self,

--- a/tests/libraries/remote/spotify/api/test_item.py
+++ b/tests/libraries/remote/spotify/api/test_item.py
@@ -8,7 +8,6 @@ from urllib.parse import parse_qs
 import pytest
 
 from musify.api.cache.backend.sqlite import SQLiteCache
-from musify.api.cache.session import CachedSession
 from musify.api.exception import APIError
 from musify.libraries.remote.core import RemoteResponse
 from musify.libraries.remote.core.enum import RemoteIDType, RemoteObjectType

--- a/tests/libraries/remote/spotify/api/test_misc.py
+++ b/tests/libraries/remote/spotify/api/test_misc.py
@@ -11,8 +11,8 @@ from tests.libraries.remote.spotify.api.mock import SpotifyMock
 from tests.utils import idfn, get_stdout, random_str
 
 
-class TestSpotifyAPICore:
-    """Tester for core endpoints of :py:class:`SpotifyAPI`"""
+class TestSpotifyAPIMisc:
+    """Tester for miscellaneous endpoints of :py:class:`SpotifyAPI`"""
 
     @pytest.mark.parametrize("method_name,kwargs,floor,ceil", [
         ("query", {"query": "valid query", "kind": ObjectType.TRACK}, 1, 50),

--- a/tests/libraries/remote/spotify/object/testers.py
+++ b/tests/libraries/remote/spotify/object/testers.py
@@ -21,12 +21,12 @@ class SpotifyCollectionLoaderTester(RemoteCollectionTester, metaclass=ABCMeta):
 
     @abstractmethod
     def item_kind(self, api: SpotifyAPI) -> RemoteObjectType:
-        """Yields the RemoteObjectType of items in this collection as a pytest.fixture"""
+        """Yields the RemoteObjectType of items in this collection as a pytest.fixture."""
         raise NotImplementedError
 
     @pytest.fixture
     def item_key(self, item_kind: RemoteObjectType) -> str:
-        """Yields the key of items in this collection as a pytest.fixture"""
+        """Yields the key of items in this collection as a pytest.fixture."""
         return item_kind.name.lower() + "s"
 
     ###########################################################################
@@ -84,7 +84,7 @@ class SpotifyCollectionLoaderTester(RemoteCollectionTester, metaclass=ABCMeta):
             api: SpotifyAPI,
             api_mock: SpotifyMock
     ):
-        """Yields the results from 'load' where no items are given as a pytest.fixture"""
+        """Yields the results from 'load' where no items are given as a pytest.fixture."""
         raise NotImplementedError
 
     def test_load_without_items(

--- a/tests/libraries/remote/spotify/test_library.py
+++ b/tests/libraries/remote/spotify/test_library.py
@@ -25,12 +25,12 @@ class TestSpotifyLibrary(RemoteLibraryTester):
     def library_unloaded(self, api: SpotifyAPI, api_mock: SpotifyMock) -> SpotifyLibrary:
         """Yields an unloaded Library object to be tested as pytest.fixture"""
         include = FilterDefinedList([pl["name"] for pl in sample(api_mock.user_playlists, k=10)])
-        return SpotifyLibrary(api=api, use_cache=False, playlist_filter=include)
+        return SpotifyLibrary(api=api, playlist_filter=include)
 
     @pytest.fixture(scope="class")
     def _library(self, api: SpotifyAPI, _api_mock: SpotifyMock) -> SpotifyLibrary:
         include = FilterDefinedList([pl["name"] for pl in sample(_api_mock.user_playlists, k=10)])
-        library = SpotifyLibrary(api=api, use_cache=False, playlist_filter=include)
+        library = SpotifyLibrary(api=api, playlist_filter=include)
         library.load()
         return library
 
@@ -40,7 +40,7 @@ class TestSpotifyLibrary(RemoteLibraryTester):
 
     def test_filter_playlists(self, api: SpotifyAPI, api_mock: SpotifyMock):
         # keep all when no include or exclude settings defined
-        library = SpotifyLibrary(api=api, use_cache=False)
+        library = SpotifyLibrary(api=api)
 
         responses = api.get_user_items(kind=RemoteObjectType.PLAYLIST)
         filtered = library._filter_playlists(responses)

--- a/tests/libraries/remote/spotify/test_library.py
+++ b/tests/libraries/remote/spotify/test_library.py
@@ -23,7 +23,7 @@ class TestSpotifyLibrary(RemoteLibraryTester):
 
     @pytest.fixture
     def library_unloaded(self, api: SpotifyAPI, api_mock: SpotifyMock) -> SpotifyLibrary:
-        """Yields an unloaded Library object to be tested as pytest.fixture"""
+        """Yields an unloaded Library object to be tested as pytest.fixture."""
         include = FilterDefinedList([pl["name"] for pl in sample(api_mock.user_playlists, k=10)])
         return SpotifyLibrary(api=api, playlist_filter=include)
 

--- a/tests/libraries/remote/spotify/test_processors.py
+++ b/tests/libraries/remote/spotify/test_processors.py
@@ -245,7 +245,7 @@ class TestSpotifyItemSearcher(RemoteItemSearcherTester):
 
     @pytest.fixture(scope="class")
     def matcher(self) -> ItemMatcher:
-        """Yields a valid :py:class:`ItemMatcher` as a pytest.fixture"""
+        """Yields a valid :py:class:`ItemMatcher` as a pytest.fixture."""
         ItemMatcher.karaoke_tags = {"karaoke", "backing", "instrumental"}
         ItemMatcher.year_range = 10
 
@@ -349,7 +349,7 @@ class TestSpotifyItemChecker(RemoteItemCheckerTester):
 
     @pytest.fixture(scope="class")
     def matcher(self) -> ItemMatcher:
-        """Yields a valid :py:class:`ItemMatcher` as a pytest.fixture"""
+        """Yields a valid :py:class:`ItemMatcher` as a pytest.fixture."""
         return ItemMatcher()
 
     @pytest.fixture

--- a/tests/libraries/remote/spotify/test_processors.py
+++ b/tests/libraries/remote/spotify/test_processors.py
@@ -295,7 +295,8 @@ class TestSpotifyItemSearcher(RemoteItemSearcherTester):
         for remote_track in map(SpotifyTrack, sample(api_mock.tracks, k=limit)):
             local_track = random_track()
             local_track.uri = None
-            local_track.remote_wrangler = wrangler
+            local_track._reader.remote_wrangler = wrangler
+            local_track._writer.remote_wrangler = wrangler
 
             local_track.title = remote_track.title
             local_track.album = remote_track.album
@@ -327,7 +328,8 @@ class TestSpotifyItemSearcher(RemoteItemSearcherTester):
             for remote_track in album:
                 local_track = random_track()
                 local_track.uri = None
-                local_track.remote_wrangler = wrangler
+                local_track._reader.remote_wrangler = wrangler
+                local_track._writer.remote_wrangler = wrangler
                 local_track.compilation = False
 
                 local_track.title = remote_track.title

--- a/tests/processors/test_compare.py
+++ b/tests/processors/test_compare.py
@@ -19,7 +19,7 @@ class TestComparer(PrettyPrinterTester):
 
     @pytest.fixture
     def track(self) -> MP3:
-        """Yields a :py:class:`MP3` object to be tested as pytest.fixture"""
+        """Yields a :py:class:`MP3` object to be tested as pytest.fixture."""
         return random_track(MP3)
 
     def test_init_fails(self):

--- a/tests/processors/test_filter.py
+++ b/tests/processors/test_filter.py
@@ -42,7 +42,7 @@ class TestFilterComparers(FilterTester):
 
     @pytest.fixture(scope="class")
     def comparers(self) -> list[Comparer]:
-        """Yields a list of :py:class:`Comparer` objects to be used as pytest.fixture"""
+        """Yields a list of :py:class:`Comparer` objects to be used as pytest.fixture."""
         return [
             Comparer(condition="is", expected="album name", field=LocalTrackField.ALBUM),
             Comparer(condition="starts with", expected="artist", field=LocalTrackField.ARTIST)
@@ -148,7 +148,7 @@ class TestFilterMatcher(FilterTester):
 
     @pytest.fixture(scope="class")
     def comparers(self) -> list[Comparer]:
-        """Yields a list :py:class:`Comparer` objects to be used as pytest.fixture"""
+        """Yields a list :py:class:`Comparer` objects to be used as pytest.fixture."""
         return [
             Comparer(condition="is", expected="album name", field=LocalTrackField.ALBUM),
             Comparer(condition="starts with", expected="artist", field=LocalTrackField.ARTIST)

--- a/tests/processors/test_filter.py
+++ b/tests/processors/test_filter.py
@@ -200,7 +200,7 @@ class TestFilterMatcher(FilterTester):
         tracks_include = sample([track for track in tracks if track not in tracks_album], 7)
 
         for i, track in enumerate(tracks_include):
-            track._path = include_paths[i]
+            track._reader.file.filename = include_paths[i]
         return tracks_include
 
     @pytest.fixture(scope="class")
@@ -210,7 +210,7 @@ class TestFilterMatcher(FilterTester):
         tracks_exclude = sample(tracks_artist, 3) + sample(tracks_include, 2)
 
         for i, track in enumerate(tracks_exclude):
-            track._path = exclude_paths[i]
+            track._reader.file.filename = exclude_paths[i]
         return tracks_exclude
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
Added
-----

* Custom API caching backend to replace dependency on `requests-cache` package.
  Currently only supports SQLite backend. More backends can be implemented in future if desired.
* Cache settings for specific `GET` request endpoints on :py:class:`.SpotifyAPI` replacing need
  for per method ``use_cache`` parameter.

Changed
-------

* Replaced ``authorise`` method from :py:class:`.APIAuthoriser` with __call__ method for class.
* Dependency injection pattern for :py:class:`.RequestHandler` and :py:class:`.RemoteAPI`.
  Now takes :py:class:`.APIAuthoriser` and :py:class:`.ResponseCache` objects for instantiation
  instead of kwargs for :py:class:`.APIAuthoriser`.
* :py:class:`.APIAuthoriser` kwargs given to :py:class:`.SpotifyAPI` now merge with default kwargs.
* Moved ``remote_wrangler`` attribute from :py:class:`.MusifyCollection` to :py:class:`.LocalCollection`.
  This attribute was only needed by :py:class:`.LocalCollection` branch of child classes.
* Moved ``logger`` attribute from :py:class:`.Library` to :py:class:`.RemoteLibrary`.

Fixed
-----

* Added missing variables to __slots__ definitions
* Correctly applied __slots__ pattern to child classes. Now works as expected.
* :py:class:`.LocalTrack` now copies tags as expected when calling ``copy.copy()``

Removed
-------

* ``use_cache`` parameter from all :py:class:`.RemoteAPI` related methods.
  Cache settings now handled by :py:class:`.ResponseCache`