### PR TITLE
add HasLength layer to fix dodgy workaround ItemLimiter

### DIFF
--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -80,6 +80,8 @@ Fixed
   to have lower case paths
 * :py:meth:`.RemoteLibrary.restore_playlists` now correctly handles the backup
   output from :py:meth:`.RemoteLibrary.backup_playlists`
+* Issue detecting stdout_handlers affecting :py:meth:`.MusifyLogger.print` and :py:meth:`.MusifyLogger.get_iterator`.
+  Now works as expected.
 
 Removed
 -------

--- a/musify/core/base.py
+++ b/musify/core/base.py
@@ -3,7 +3,7 @@ The fundamental core classes for the entire package.
 """
 from __future__ import annotations
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Hashable
 from typing import Any
 
@@ -40,7 +40,7 @@ class MusifyObject(AttributePrinter):
         return self.name > other.name
 
 
-class MusifyItem(MusifyObject, Hashable, metaclass=ABCMeta):
+class MusifyItem(MusifyObject, Hashable, ABC):
     """Generic class for storing an item."""
 
     __slots__ = ()
@@ -76,7 +76,7 @@ class MusifyItem(MusifyObject, Hashable, metaclass=ABCMeta):
 
 
 # noinspection PyPropertyDefinition
-class MusifyItemSettable(MusifyItem, metaclass=ABCMeta):
+class MusifyItemSettable(MusifyItem, ABC):
     """Generic class for storing an item that can have select properties modified."""
 
     __slots__ = ()
@@ -92,3 +92,15 @@ class MusifyItemSettable(MusifyItem, metaclass=ABCMeta):
         raise NotImplementedError
 
     uri = property(lambda self: self._uri_getter(), lambda self, v: self._uri_setter(v))
+
+
+class HasLength(ABC):
+    """Simple protocol for an object which has a length"""
+
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def length(self):
+        """Total duration of this object in seconds"""
+        raise NotImplementedError

--- a/musify/file/base.py
+++ b/musify/file/base.py
@@ -1,7 +1,7 @@
 """
 Generic base classes and functions for file operations.
 """
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Hashable
 from datetime import datetime
 from glob import glob
@@ -11,7 +11,7 @@ from typing import Any
 from musify.file.exception import InvalidFileType, FileDoesNotExistError
 
 
-class File(Hashable, metaclass=ABCMeta):
+class File(Hashable, ABC):
     """Generic class for representing a file on a system."""
 
     __slots__ = ()

--- a/musify/libraries/core/collection.py
+++ b/musify/libraries/core/collection.py
@@ -8,7 +8,7 @@ from collections.abc import MutableSequence, Iterable, Mapping, Collection
 from dataclasses import dataclass
 from typing import Any, SupportsIndex, Self
 
-from musify.core.base import MusifyObject, MusifyItem
+from musify.core.base import MusifyObject, MusifyItem, HasLength
 from musify.core.enum import Field
 from musify.exception import MusifyTypeError, MusifyKeyError, MusifyAttributeError
 from musify.file.base import File
@@ -105,7 +105,7 @@ class RemoteURLEXTGetter(ItemGetterStrategy):
         return item.url_ext
 
 
-class MusifyCollection[T: MusifyItem](MusifyObject, MutableSequence[T], ABC):
+class MusifyCollection[T: MusifyItem](MusifyObject, HasLength, MutableSequence[T], ABC):
     """Generic class for storing a collection of musify items."""
 
     __slots__ = ()

--- a/musify/libraries/core/object.py
+++ b/musify/libraries/core/object.py
@@ -9,13 +9,13 @@ from collections.abc import Collection, Mapping, Iterable
 from copy import deepcopy
 from typing import Self
 
-from musify.core.base import MusifyItem
+from musify.core.base import MusifyItem, HasLength
 from musify.exception import MusifyTypeError
 from musify.libraries.core.collection import MusifyCollection
 from musify.libraries.remote.core.enum import RemoteObjectType
 
 
-class Track(MusifyItem, ABC):
+class Track(MusifyItem, HasLength, ABC):
     """Represents a track including its metadata/tags/properties."""
 
     __slots__ = ()

--- a/musify/processors/base.py
+++ b/musify/processors/base.py
@@ -2,7 +2,7 @@
 Base classes for all processors in this module. Also contains decorators for use in implementations.
 """
 import logging
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Mapping, Callable, Collection, Iterable, MutableSequence
 from functools import partial, update_wrapper
 from typing import Any, Optional
@@ -13,13 +13,13 @@ from musify.processors.exception import ProcessorLookupError
 from musify.utils import get_user_input, get_max_width, align_string
 
 
-class Processor(PrettyPrinter, metaclass=ABCMeta):
+class Processor(PrettyPrinter, ABC):
     """Generic base class for processors"""
 
     __slots__ = ()
 
 
-class InputProcessor(Processor, metaclass=ABCMeta):
+class InputProcessor(Processor, ABC):
     """
     Processor that gets user input as part of it processing.
 
@@ -81,7 +81,7 @@ class dynamicprocessormethod:
 
 
 # noinspection SpellCheckingInspection
-class DynamicProcessor(Processor, metaclass=ABCMeta):
+class DynamicProcessor(Processor, ABC):
     """
     Base class for implementations with :py:func:`dynamicprocessormethod` methods.
 
@@ -159,7 +159,7 @@ class DynamicProcessor(Processor, metaclass=ABCMeta):
         return self._processor_method(*args, **kwargs)
 
 
-class Filter[T](Processor, metaclass=ABCMeta):
+class Filter[T](Processor, ABC):
     """Base class for filtering down values based on some settings"""
 
     __slots__ = ("_transform",)
@@ -197,7 +197,7 @@ class Filter[T](Processor, metaclass=ABCMeta):
         return self.ready
 
 
-class FilterComposite[T](Filter[T], Collection[Filter], metaclass=ABCMeta):
+class FilterComposite[T](Filter[T], Collection[Filter], ABC):
     """Composite filter which filters based on many :py:class:`Filter` objects"""
 
     __slots__ = ("filters",)

--- a/musify/processors/limit.py
+++ b/musify/processors/limit.py
@@ -6,7 +6,7 @@ from functools import reduce
 from operator import mul
 from random import shuffle
 
-from musify.core.base import MusifyItem
+from musify.core.base import MusifyItem, HasLength
 from musify.core.enum import MusifyEnum, Fields
 from musify.file.base import File
 from musify.libraries.core.object import Track
@@ -149,7 +149,7 @@ class ItemLimiter(DynamicProcessor):
         :raise ItemLimiterError: When the given limit type cannot be found
         """
         if 10 < self.kind.value < 20:
-            if getattr(item, "length", None) is None:  # TODO: there should be a better way of handling this...
+            if not isinstance(item, HasLength):
                 raise LimiterProcessorError("The given item cannot be limited on length as it does not have a length.")
 
             factors = (1, 60, 60, 24, 7)[:self.kind.value % 10]

--- a/tests/core/base.py
+++ b/tests/core/base.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 import pytest
 
@@ -7,7 +7,7 @@ from musify.core.printer import PrettyPrinter
 from tests.core.printer import PrettyPrinterTester
 
 
-class MusifyItemTester(PrettyPrinterTester, metaclass=ABCMeta):
+class MusifyItemTester(PrettyPrinterTester, ABC):
     """Run generic tests for :py:class:`MusifyItem` implementations"""
 
     @abstractmethod

--- a/tests/core/enum.py
+++ b/tests/core/enum.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, ABCMeta
+from abc import ABC, abstractmethod
 from collections.abc import Container
 
 from musify.core.base import MusifyObject
@@ -24,7 +24,7 @@ class EnumTester(ABC):
         assert self.cls.from_value(*all_enums, fail_on_many=False) == set(all_enums)
 
 
-class FieldTester(EnumTester, metaclass=ABCMeta):
+class FieldTester(EnumTester, ABC):
     """Run generic tests for :py:class:`Field` enum implementations"""
 
     @abstractmethod
@@ -64,7 +64,7 @@ class FieldTester(EnumTester, metaclass=ABCMeta):
             assert isinstance(getattr(reference_cls, name), property)
 
 
-class TagFieldTester(FieldTester, metaclass=ABCMeta):
+class TagFieldTester(FieldTester, ABC):
     """Run generic tests for :py:class:`TagField` enum implementations"""
 
     @property

--- a/tests/libraries/core/collection.py
+++ b/tests/libraries/core/collection.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from copy import deepcopy
 from random import sample
@@ -17,7 +17,7 @@ from musify.libraries.remote.core.object import RemoteCollectionLoader
 from tests.core.printer import PrettyPrinterTester
 
 
-class MusifyCollectionTester(PrettyPrinterTester, metaclass=ABCMeta):
+class MusifyCollectionTester(PrettyPrinterTester, ABC):
     """
     Run generic tests for :py:class:`MusifyCollection` implementations.
     The collection must have 3 or more items and all items must be unique.
@@ -210,7 +210,7 @@ class MusifyCollectionTester(PrettyPrinterTester, metaclass=ABCMeta):
         assert collection.intersection(other) == collection.items
 
 
-class PlaylistTester(MusifyCollectionTester, metaclass=ABCMeta):
+class PlaylistTester(MusifyCollectionTester, ABC):
 
     @abstractmethod
     def playlist(self, *args, **kwargs) -> Playlist:
@@ -291,7 +291,7 @@ class PlaylistTester(MusifyCollectionTester, metaclass=ABCMeta):
         assert playlist[initial_count:] == other.items
 
 
-class LibraryTester(MusifyCollectionTester, metaclass=ABCMeta):
+class LibraryTester(MusifyCollectionTester, ABC):
     """
     Run generic tests for :py:class:`Library` implementations.
     The collection must have 3 or more playlists and all playlists must be unique.

--- a/tests/libraries/local/library/testers.py
+++ b/tests/libraries/local/library/testers.py
@@ -1,8 +1,8 @@
-from abc import ABCMeta
+from abc import ABC
 
 from tests.libraries.core.collection import LibraryTester
 from tests.libraries.local.track.testers import LocalCollectionTester
 
 
-class LocalLibraryTester(LibraryTester, LocalCollectionTester, metaclass=ABCMeta):
+class LocalLibraryTester(LibraryTester, LocalCollectionTester, ABC):
     pass

--- a/tests/libraries/local/playlist/testers.py
+++ b/tests/libraries/local/playlist/testers.py
@@ -1,8 +1,8 @@
-from abc import ABCMeta
+from abc import ABC
 
 from tests.libraries.core.collection import PlaylistTester
 from tests.libraries.local.track.testers import LocalCollectionTester
 
 
-class LocalPlaylistTester(PlaylistTester, LocalCollectionTester, metaclass=ABCMeta):
+class LocalPlaylistTester(PlaylistTester, LocalCollectionTester, ABC):
     pass

--- a/tests/libraries/local/track/testers.py
+++ b/tests/libraries/local/track/testers.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta
+from abc import ABC
 from collections.abc import Iterable, Collection
 from random import randrange, sample
 
@@ -13,7 +13,7 @@ from tests.libraries.local.track.utils import random_tracks
 from tests.libraries.remote.spotify.api.mock import SpotifyMock
 
 
-class LocalCollectionTester(MusifyCollectionTester, metaclass=ABCMeta):
+class LocalCollectionTester(MusifyCollectionTester, ABC):
 
     @pytest.fixture
     def collection_merge_items(self) -> Iterable[LocalTrack]:

--- a/tests/libraries/remote/core/library.py
+++ b/tests/libraries/remote/core/library.py
@@ -1,5 +1,5 @@
 import re
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Collection, Mapping
 from copy import copy, deepcopy
 from random import choice
@@ -17,7 +17,7 @@ from tests.libraries.remote.core.object import RemoteCollectionTester
 from tests.libraries.remote.core.utils import RemoteMock
 
 
-class RemoteLibraryTester(RemoteCollectionTester, LibraryTester, metaclass=ABCMeta):
+class RemoteLibraryTester(RemoteCollectionTester, LibraryTester, ABC):
 
     @abstractmethod
     def collection_merge_items(self, *args, **kwargs) -> list[RemoteTrack]:

--- a/tests/libraries/remote/core/object.py
+++ b/tests/libraries/remote/core/object.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Any
 
@@ -15,7 +15,7 @@ from tests.libraries.local.track.utils import random_tracks
 from tests.libraries.remote.core.utils import RemoteMock
 
 
-class RemoteCollectionTester(MusifyCollectionTester, metaclass=ABCMeta):
+class RemoteCollectionTester(MusifyCollectionTester, ABC):
 
     @abstractmethod
     def collection_merge_items(self, *args, **kwargs) -> Iterable[RemoteItem]:
@@ -60,7 +60,7 @@ class RemoteCollectionTester(MusifyCollectionTester, metaclass=ABCMeta):
             assert collection["this key does not exist"]
 
 
-class RemotePlaylistTester(RemoteCollectionTester, PlaylistTester, metaclass=ABCMeta):
+class RemotePlaylistTester(RemoteCollectionTester, PlaylistTester, ABC):
 
     @staticmethod
     def _get_payload_from_request(request: RequestCall) -> dict[str, Any] | None:

--- a/tests/libraries/remote/core/processors/check.py
+++ b/tests/libraries/remote/core/processors/check.py
@@ -1,5 +1,5 @@
 import re
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from itertools import batched
 from random import randrange, choice
 
@@ -20,7 +20,7 @@ from tests.libraries.remote.spotify.utils import random_uri, random_uris
 from tests.utils import random_str, get_stdout
 
 
-class RemoteItemCheckerTester(PrettyPrinterTester, metaclass=ABCMeta):
+class RemoteItemCheckerTester(PrettyPrinterTester, ABC):
     """Run generic tests for :py:class:`RemoteItemSearcher` implementations."""
 
     @pytest.fixture

--- a/tests/libraries/remote/core/processors/search.py
+++ b/tests/libraries/remote/core/processors/search.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Iterable, Callable, Awaitable
 from copy import copy
 from urllib.parse import unquote
@@ -19,7 +19,7 @@ from tests.libraries.local.track.utils import random_track, random_tracks
 from tests.libraries.remote.core.utils import RemoteMock
 
 
-class RemoteItemSearcherTester(PrettyPrinterTester, metaclass=ABCMeta):
+class RemoteItemSearcherTester(PrettyPrinterTester, ABC):
     """Run generic tests for :py:class:`RemoteItemSearcher` implementations."""
 
     @pytest.fixture

--- a/tests/libraries/remote/spotify/object/testers.py
+++ b/tests/libraries/remote/spotify/object/testers.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Any
 from urllib.parse import unquote
@@ -13,7 +13,7 @@ from tests.libraries.remote.core.object import RemoteCollectionTester
 from tests.libraries.remote.spotify.api.mock import SpotifyMock
 
 
-class SpotifyCollectionLoaderTester(RemoteCollectionTester, metaclass=ABCMeta):
+class SpotifyCollectionLoaderTester(RemoteCollectionTester, ABC):
 
     @abstractmethod
     def collection_merge_items(self, *args, **kwargs) -> Iterable[SpotifyItem]:

--- a/tests/log/test_logger.py
+++ b/tests/log/test_logger.py
@@ -33,15 +33,15 @@ def logger() -> MusifyLogger:
 def test_print(logger: MusifyLogger, capfd: pytest.CaptureFixture):
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.WARNING)
-    logger.addHandler(handler)
+    logging._handlers[handler.name] = handler
 
-    logger.print(logging.ERROR)  # ERROR is above handler level, print line
+    logger.print(logging.ERROR)  # ERROR is above handler level
     assert capfd.readouterr().out == '\n'
 
-    logger.print(logging.WARNING)  # WARNING is below handler level, print line
+    logger.print(logging.WARNING)  # WARNING is at handler level
     assert capfd.readouterr().out == '\n'
 
-    logger.print(logging.INFO)  # INFO is below handler level, don't print line
+    logger.print(logging.INFO)  # INFO is below handler level
     assert capfd.readouterr().out == ''
 
     # compact is True, never print lines
@@ -76,7 +76,7 @@ def test_file_paths(logger: MusifyLogger):
 def test_getting_iterator_as_progress_bar(logger: MusifyLogger):
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.DEBUG)  # forces leave to be False
-    logger.addHandler(handler)
+    logging._handlers[handler.name] = handler
     logger._bars.clear()
 
     bar = logger.get_iterator(iterable=range(0, 50), initial=10, disable=True, file=sys.stderr)

--- a/tests/processors/test_filter.py
+++ b/tests/processors/test_filter.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta
+from abc import ABC
 from random import sample, shuffle, randrange
 
 import pytest
@@ -16,7 +16,7 @@ from tests.libraries.local.utils import path_track_all
 from tests.utils import random_str, path_resources
 
 
-class FilterTester(PrettyPrinterTester, metaclass=ABCMeta):
+class FilterTester(PrettyPrinterTester, ABC):
     pass
 
 


### PR DESCRIPTION
Fixed
-----

* Issue detecting stdout_handlers affecting :py:meth:`.MusifyLogger.print` and :py:meth:`.MusifyLogger.get_iterator`.
  Now works as expected.