### PR TITLE
improve performance for printing `LocalCollection` objects

### DIFF
--- a/docs/_howto/scripts/remote.new-music/p4.py
+++ b/docs/_howto/scripts/remote.new-music/p4.py
@@ -1,10 +1,10 @@
 from p3 import *
 
 from musify.libraries.remote.core.enum import RemoteObjectType
-from musify.libraries.remote.spotify.object import SpotifyAlbum
+from musify.libraries.remote.core.object import RemoteAlbum
 
 
-async def get_albums(library: RemoteLibrary, start: date, end: date) -> list[SpotifyAlbum]:
+async def get_albums(library: RemoteLibrary, start: date, end: date) -> list[RemoteAlbum]:
     """
     Get the albums that match the ``start`` and ``end`` date range from a given ``library``
     and get the tracks on those albums if needed.

--- a/docs/_howto/scripts/sync/p99.py
+++ b/docs/_howto/scripts/sync/p99.py
@@ -9,4 +9,4 @@ playlist = "<YOUR PLAYLIST'S NAME>"  # case sensitive
 
 asyncio.run(match_albums_to_remote(albums, remote_library.factory))
 asyncio.run(sync_albums(albums, remote_library.factory))
-asyncio.run(sync_local_library_with_remote(playlist, local_library, remote_library))
+asyncio.run(sync_local_playlist_with_remote(playlist, local_library, remote_library))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ author = PROGRAM_OWNER_NAME
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
+# noinspection SpellCheckingInspection
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx_rtd_theme",
@@ -27,7 +28,9 @@ extensions = [
     "autodocsumm",
     "sphinxext.opengraph",
 ]
+# noinspection SpellCheckingInspection
 autodoc_member_order = "bysource"
+# noinspection SpellCheckingInspection
 autodoc_default_options = {
     "autosummary": True,
     "members": True,

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -31,7 +31,7 @@ Setup your development environment
       pip install -e '.[dev]'  # installs the `test` dependencies + dependencies for linting and other development uses
       pip install -e '.[docs]'  # installs just the core package + the required dependencies for building documentation
 
-6. Optionally, to ensure inhreitance diagrams in the documentation render correctly, install graphviz.
+6. Optionally, to ensure inheritance diagrams in the documentation render correctly, install graphviz.
    See `here <https://graphviz.org/download/>`_ for platform-specific info on how to install graphviz.
 
 Making changes and testing

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -93,6 +93,8 @@ Removed
 * ``use_cache`` parameter from all :py:class:`.RemoteAPI` related methods.
   Cache settings now handled by :py:class:`.ResponseCache`
 * ThreadPoolExecutor use on :py:class:`.RemoteItemSearcher`. Now uses asynchronous logic instead.
+* `last_modified` field as attribute to ignore when getting attributes
+  to print on `LocalCollection` to improve performance
 
 Documentation
 -------------

--- a/musify/api/cache/backend/base.py
+++ b/musify/api/cache/backend/base.py
@@ -1,6 +1,6 @@
 import logging
-from abc import ABC, abstractmethod
-from collections.abc import MutableMapping, Callable, Collection, Hashable, AsyncIterable, Mapping, Awaitable
+from abc import ABCMeta, abstractmethod
+from collections.abc import MutableMapping, Callable, Collection, AsyncIterable, Mapping, Awaitable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Self, AsyncContextManager
@@ -21,7 +21,7 @@ DEFAULT_EXPIRE: timedelta = timedelta(weeks=1)
 
 
 @dataclass
-class RequestSettings(ABC):
+class RequestSettings(metaclass=ABCMeta):
     """Settings for a request type for a given endpoint to be used to configure a repository in the cache backend."""
     #: That name of the repository in the backend
     name: str
@@ -47,7 +47,7 @@ class RequestSettings(ABC):
         raise NotImplementedError
 
 
-class ResponseRepository[K, V](AsyncIterable[tuple[K, V]], Awaitable, Hashable, ABC):
+class ResponseRepository[K, V](AsyncIterable[tuple[K, V]], Awaitable, metaclass=ABCMeta):
     """
     Represents a repository in the backend cache, providing a dict-like interface
     for interacting with this repository.

--- a/musify/core/base.py
+++ b/musify/core/base.py
@@ -3,15 +3,14 @@ The fundamental core classes for the entire package.
 """
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from collections.abc import Hashable
+from abc import ABCMeta, abstractmethod
 from typing import Any
 
 from musify.core.enum import TagField
 from musify.core.printer import AttributePrinter
 
 
-class MusifyObject(AttributePrinter):
+class MusifyObject(AttributePrinter, metaclass=ABCMeta):
     """Generic base class for any nameable and taggable object."""
 
     __slots__ = ("_clean_tags",)
@@ -40,7 +39,7 @@ class MusifyObject(AttributePrinter):
         return self.name > other.name
 
 
-class MusifyItem(MusifyObject, Hashable, ABC):
+class MusifyItem(MusifyObject, metaclass=ABCMeta):
     """Generic class for storing an item."""
 
     __slots__ = ()
@@ -76,7 +75,7 @@ class MusifyItem(MusifyObject, Hashable, ABC):
 
 
 # noinspection PyPropertyDefinition
-class MusifyItemSettable(MusifyItem, ABC):
+class MusifyItemSettable(MusifyItem, metaclass=ABCMeta):
     """Generic class for storing an item that can have select properties modified."""
 
     __slots__ = ()
@@ -94,7 +93,7 @@ class MusifyItemSettable(MusifyItem, ABC):
     uri = property(lambda self: self._uri_getter(), lambda self, v: self._uri_setter(v))
 
 
-class HasLength(ABC):
+class HasLength(metaclass=ABCMeta):
     """Simple protocol for an object which has a length"""
 
     __slots__ = ()

--- a/musify/core/base.py
+++ b/musify/core/base.py
@@ -90,7 +90,11 @@ class MusifyItemSettable(MusifyItem, metaclass=ABCMeta):
         """Set both the ``uri`` property and the ``has_uri`` property ."""
         raise NotImplementedError
 
-    uri = property(lambda self: self._uri_getter(), lambda self, v: self._uri_setter(v))
+    uri = property(
+        fget=lambda self: self._uri_getter(),
+        fset=lambda self, v: self._uri_setter(v),
+        doc="URI (Uniform Resource Indicator) is the unique identifier for this item."
+    )
 
 
 class HasLength(metaclass=ABCMeta):

--- a/musify/core/printer.py
+++ b/musify/core/printer.py
@@ -2,7 +2,7 @@
 The fundamental core printer classes for the entire package.
 """
 import re
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, date
@@ -12,7 +12,7 @@ from musify.types import UnitIterable, JSON, DictJSON, JSON_VALUE
 from musify.utils import to_collection
 
 
-class PrettyPrinter(ABC):
+class PrettyPrinter(metaclass=ABCMeta):
     """Generic base class for pretty printing. Classes can inherit this class to gain pretty print functionality."""
 
     __slots__ = ()

--- a/musify/core/result.py
+++ b/musify/core/result.py
@@ -1,11 +1,11 @@
 """
 The fundamental core result classes for the entire package.
 """
-from abc import ABC
+from abc import ABCMeta
 from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class Result(ABC):
+class Result(metaclass=ABCMeta):
     """Stores the results of an operation"""
     pass

--- a/musify/file/base.py
+++ b/musify/file/base.py
@@ -1,8 +1,7 @@
 """
 Generic base classes and functions for file operations.
 """
-from abc import ABC, abstractmethod
-from collections.abc import Hashable
+from abc import ABCMeta, abstractmethod
 from datetime import datetime
 from glob import glob
 from os.path import splitext, basename, dirname, getsize, getmtime, getctime, exists, join
@@ -11,7 +10,7 @@ from typing import Any
 from musify.file.exception import InvalidFileType, FileDoesNotExistError
 
 
-class File(Hashable, ABC):
+class File(metaclass=ABCMeta):
     """Generic class for representing a file on a system."""
 
     __slots__ = ()

--- a/musify/libraries/collection.py
+++ b/musify/libraries/collection.py
@@ -20,6 +20,7 @@ class BasicCollection[T: MusifyItem](MusifyCollection[T]):
     """
 
     __slots__ = ("_name", "_items")
+    __attributes_ignore__ = ("date_modified",)
 
     @staticmethod
     def _validate_item_type(items: Any | Iterable[Any]) -> bool:

--- a/musify/libraries/collection.py
+++ b/musify/libraries/collection.py
@@ -20,7 +20,6 @@ class BasicCollection[T: MusifyItem](MusifyCollection[T]):
     """
 
     __slots__ = ("_name", "_items")
-    __attributes_ignore__ = ("date_modified",)
 
     @staticmethod
     def _validate_item_type(items: Any | Iterable[Any]) -> bool:

--- a/musify/libraries/core/collection.py
+++ b/musify/libraries/core/collection.py
@@ -3,7 +3,7 @@ The fundamental core collection classes for the entire package.
 """
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import MutableSequence, Iterable, Mapping, Collection
 from dataclasses import dataclass
 from typing import Any, SupportsIndex, Self
@@ -19,7 +19,7 @@ from musify.types import UnitSequence
 
 
 @dataclass
-class ItemGetterStrategy(ABC):
+class ItemGetterStrategy(metaclass=ABCMeta):
     """Abstract base class for strategies relating to __getitem__ operations on a :py:class:`MusifyCollection`"""
 
     key: str
@@ -105,7 +105,7 @@ class RemoteURLEXTGetter(ItemGetterStrategy):
         return item.url_ext
 
 
-class MusifyCollection[T: MusifyItem](MusifyObject, HasLength, MutableSequence[T], ABC):
+class MusifyCollection[T: MusifyItem](MusifyObject, MutableSequence[T], HasLength):
     """Generic class for storing a collection of musify items."""
 
     __slots__ = ()

--- a/musify/libraries/core/object.py
+++ b/musify/libraries/core/object.py
@@ -19,7 +19,7 @@ class Track(MusifyItem, HasLength, metaclass=ABCMeta):
     """Represents a track including its metadata/tags/properties."""
 
     __slots__ = ()
-    __attributes_ignore__ = "name"
+    __attributes_ignore__ = ("name",)
 
     # noinspection PyPropertyDefinition
     @classmethod
@@ -172,7 +172,7 @@ class Playlist[T: Track](MusifyCollection[T], metaclass=ABCMeta):
 
     __slots__ = ()
     __attributes_classes__ = MusifyCollection
-    __attributes_ignore__ = "items"
+    __attributes_ignore__ = ("items",)
 
     # noinspection PyPropertyDefinition
     @classmethod
@@ -293,7 +293,7 @@ class Library[T: Track](MusifyCollection[T], metaclass=ABCMeta):
 
     __slots__ = ()
     __attributes_classes__ = MusifyCollection
-    __attributes_ignore__ = "items"
+    __attributes_ignore__ = ("items",)
 
     @property
     @abstractmethod

--- a/musify/libraries/core/object.py
+++ b/musify/libraries/core/object.py
@@ -4,7 +4,7 @@ The core abstract implementations of :py:class:`MusifyItem` and :py:class:`Musif
 from __future__ import annotations
 
 import datetime
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Collection, Mapping, Iterable
 from copy import deepcopy
 from typing import Self
@@ -15,7 +15,7 @@ from musify.libraries.core.collection import MusifyCollection
 from musify.libraries.remote.core.enum import RemoteObjectType
 
 
-class Track(MusifyItem, HasLength, ABC):
+class Track(MusifyItem, HasLength, metaclass=ABCMeta):
     """Represents a track including its metadata/tags/properties."""
 
     __slots__ = ()
@@ -167,7 +167,7 @@ class Track(MusifyItem, HasLength, ABC):
         raise NotImplementedError
 
 
-class Playlist[T: Track](MusifyCollection[T], ABC):
+class Playlist[T: Track](MusifyCollection[T], metaclass=ABCMeta):
     """A playlist of items and their derived properties/objects."""
 
     __slots__ = ()
@@ -288,7 +288,7 @@ class Playlist[T: Track](MusifyCollection[T], ABC):
         return self
 
 
-class Library[T: Track](MusifyCollection[T], ABC):
+class Library[T: Track](MusifyCollection[T], metaclass=ABCMeta):
     """A library of items and playlists and other object types."""
 
     __slots__ = ()
@@ -405,7 +405,7 @@ class Library[T: Track](MusifyCollection[T], ABC):
             self.playlists[name].merge(playlist, reference=reference.get(name))
 
 
-class Folder[T: Track](MusifyCollection[T], ABC):
+class Folder[T: Track](MusifyCollection[T], metaclass=ABCMeta):
     """
     A folder of items and their derived properties/objects
     """
@@ -472,7 +472,7 @@ class Folder[T: Track](MusifyCollection[T], ABC):
         return sum(lengths) if lengths else None
 
 
-class Album[T: Track](MusifyCollection[T], ABC):
+class Album[T: Track](MusifyCollection[T], metaclass=ABCMeta):
     """An album of items and their derived properties/objects."""
 
     __slots__ = ()
@@ -596,7 +596,7 @@ class Album[T: Track](MusifyCollection[T], ABC):
         raise NotImplementedError
 
 
-class Artist[T: (Track, Album)](MusifyCollection[T], ABC):
+class Artist[T: (Track, Album)](MusifyCollection[T], metaclass=ABCMeta):
     """An artist of items and their derived properties/objects."""
 
     __slots__ = ()
@@ -668,7 +668,7 @@ class Artist[T: (Track, Album)](MusifyCollection[T], ABC):
         raise NotImplementedError
 
 
-class Genre[T: Track](MusifyCollection[T], ABC):
+class Genre[T: Track](MusifyCollection[T], metaclass=ABCMeta):
     """A genre of items and their derived properties/objects."""
 
     __slots__ = ()

--- a/musify/libraries/local/base.py
+++ b/musify/libraries/local/base.py
@@ -1,13 +1,13 @@
 """
 Core abstract classes for the :py:mod:`Local` module.
 """
-from abc import ABC
+from abc import ABCMeta
 
 from musify.core.base import MusifyItemSettable
 from musify.file.base import File
 
 
-class LocalItem(File, MusifyItemSettable, ABC):
+class LocalItem(File, MusifyItemSettable, metaclass=ABCMeta):
     """Generic base class for locally-stored items"""
 
     __slots__ = ()

--- a/musify/libraries/local/collection.py
+++ b/musify/libraries/local/collection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping, Collection, Iterable, Container
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
@@ -28,7 +28,7 @@ from musify.utils import get_most_common_values, to_collection, align_string, ge
 _max_str = "z" * 50
 
 
-class LocalCollection[T: LocalTrack](MusifyCollection[T], ABC):
+class LocalCollection[T: LocalTrack](MusifyCollection[T], metaclass=ABCMeta):
     """
     Generic class for storing a collection of local tracks.
 
@@ -170,7 +170,7 @@ class LocalCollection[T: LocalTrack](MusifyCollection[T], ABC):
             self.logger.print()
 
 
-class LocalCollectionFiltered[T: LocalItem](LocalCollection[T], ABC):
+class LocalCollectionFiltered[T: LocalItem](LocalCollection[T], metaclass=ABCMeta):
     """
     Generic class for storing and filtering on a collection of local tracks
     with methods for enriching the attributes of this object from the attributes of the collection of tracks

--- a/musify/libraries/local/collection.py
+++ b/musify/libraries/local/collection.py
@@ -37,7 +37,7 @@ class LocalCollection[T: LocalTrack](MusifyCollection[T], metaclass=ABCMeta):
     """
 
     __slots__ = ("logger", "remote_wrangler")
-    __attributes_ignore__ = ("track_paths", "track_total")
+    __attributes_ignore__ = ("track_total", "last_modified")
 
     @staticmethod
     def _validate_item_type(items: Any | Iterable[Any]) -> bool:

--- a/musify/libraries/local/library/library.py
+++ b/musify/libraries/local/library/library.py
@@ -59,7 +59,7 @@ class LocalLibrary(LocalCollection[LocalTrack], Library[LocalTrack]):
         "errors",
     )
     __attributes_classes__ = (Library, LocalCollection)
-    __attributes_ignore__ = "tracks_in_playlists"
+    __attributes_ignore__ = ("tracks_in_playlists",)
 
     # noinspection PyPropertyDefinition
     @classmethod
@@ -452,7 +452,6 @@ class LocalLibrary(LocalCollection[LocalTrack], Library[LocalTrack]):
         if playlists is not None:
             tracks: Mapping[str, Mapping[str, Any]] = {track["path"]: track for track in self_json["tracks"]}
 
-            # noinspection PyProtectedMember
             def _get_playlist_json(pl: LocalPlaylist) -> tuple[str, dict[str, Any]]:
                 pl_attributes = pl._get_attributes()
                 pl_attributes["tracks"] = []

--- a/musify/libraries/local/playlist/base.py
+++ b/musify/libraries/local/playlist/base.py
@@ -1,7 +1,7 @@
 """
 Base implementation for the functionality of a local playlist.
 """
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Collection
 from datetime import datetime
 from os.path import dirname, join, getmtime, getctime, exists
@@ -18,7 +18,7 @@ from musify.processors.limit import ItemLimiter
 from musify.processors.sort import ItemSorter
 
 
-class LocalPlaylist[T: Filter[LocalTrack]](LocalCollection[LocalTrack], Playlist[LocalTrack], File, ABC):
+class LocalPlaylist[T: Filter[LocalTrack]](LocalCollection[LocalTrack], Playlist[LocalTrack], File, metaclass=ABCMeta):
     """
     Generic class for loading and manipulating local playlists.
 

--- a/musify/libraries/local/track/tags/base.py
+++ b/musify/libraries/local/track/tags/base.py
@@ -1,7 +1,7 @@
 """
 The base processor definition for reading/manipulating tag data in an audio file.
 """
-from abc import ABC
+from abc import ABCMeta
 
 import mutagen
 
@@ -10,7 +10,7 @@ from musify.libraries.local.track.field import LocalTrackField
 from musify.libraries.remote.core.processors.wrangle import RemoteDataWrangler
 
 
-class TagProcessor[T: mutagen.FileType](ABC):
+class TagProcessor[T: mutagen.FileType](metaclass=ABCMeta):
     """
     Base tag processor for reading/writing of tag metadata to a file.
 

--- a/musify/libraries/local/track/tags/reader.py
+++ b/musify/libraries/local/track/tags/reader.py
@@ -2,7 +2,7 @@
 Implements all functionality pertaining to reading metadata/tags/properties for a :py:class:`LocalTrack`.
 """
 import re
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
 from typing import Any
 
@@ -20,7 +20,7 @@ except ImportError:
     ImageType = None
 
 
-class TagReader[T: mutagen.FileType](TagProcessor, ABC):
+class TagReader[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
     """Functionality for reading tags/metadata/properties from a mutagen object."""
 
     __slots__ = ()

--- a/musify/libraries/local/track/tags/writer.py
+++ b/musify/libraries/local/track/tags/writer.py
@@ -1,7 +1,7 @@
 """
 Implements all functionality pertaining to writing and deleting metadata/tags/properties for a :py:class:`LocalTrack`.
 """
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping, Collection, Callable
 from dataclasses import dataclass
 from typing import Any
@@ -26,7 +26,7 @@ class SyncResultTrack(Result):
     updated: Mapping[Tags, int]
 
 
-class TagWriter[T: mutagen.FileType](TagProcessor, ABC):
+class TagWriter[T: mutagen.FileType](TagProcessor, metaclass=ABCMeta):
     """Functionality for updating and removing tags/metadata/properties from a mutagen object."""
 
     __slots__ = ()

--- a/musify/libraries/local/track/track.py
+++ b/musify/libraries/local/track/track.py
@@ -3,7 +3,7 @@ Compositely combine reader and writer classes for metadata/tags/properties opera
 """
 import datetime
 import os
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from copy import deepcopy
 from os.path import join, exists, dirname
 from typing import Any, Self
@@ -25,7 +25,7 @@ from musify.types import UnitIterable
 from musify.utils import to_collection
 
 
-class LocalTrack[T: mutagen.FileType, U: TagReader, V: TagWriter](LocalItem, Track, ABC):
+class LocalTrack[T: mutagen.FileType, U: TagReader, V: TagWriter](LocalItem, Track, metaclass=ABCMeta):
     """
     Generic track object for extracting, modifying, and saving metadata/tags/properties for a given file.
 

--- a/musify/libraries/local/track/track.py
+++ b/musify/libraries/local/track/track.py
@@ -66,7 +66,7 @@ class LocalTrack[T: mutagen.FileType, U: TagReader, V: TagWriter](LocalItem, Tra
         "_play_count",
     )
     __attributes_classes__ = (Track, LocalItem)
-    __attributes_ignore__ = "tag_map"
+    __attributes_ignore__ = ("tag_map",)
 
     _load_on_init = True
 

--- a/musify/libraries/remote/core/api.py
+++ b/musify/libraries/remote/core/api.py
@@ -4,7 +4,7 @@ The framework for interacting with a remote API.
 All methods that interact with the API should return raw, unprocessed responses.
 """
 import logging
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Collection, MutableMapping, Mapping, Sequence
 from typing import Any, Self, AsyncContextManager
 
@@ -22,7 +22,7 @@ from musify.types import UnitSequence, JSON, UnitList
 from musify.utils import align_string, to_collection
 
 
-class RemoteAPI(AsyncContextManager, ABC):
+class RemoteAPI(AsyncContextManager, metaclass=ABCMeta):
     """
     Collection of endpoints for a remote API.
     See :py:class:`RequestHandler` and :py:class:`APIAuthoriser`

--- a/musify/libraries/remote/core/base.py
+++ b/musify/libraries/remote/core/base.py
@@ -3,7 +3,7 @@ Core abstract classes for the :py:mod:`Remote` module.
 
 These define the foundations of any remote object or item.
 """
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
 from typing import Any, Self, AsyncContextManager
 
@@ -13,7 +13,7 @@ from musify.libraries.remote.core import RemoteResponse
 from musify.libraries.remote.core.api import RemoteAPI
 
 
-class RemoteObject[T: (RemoteAPI | None)](RemoteResponse, AsyncContextManager, ABC):
+class RemoteObject[T: (RemoteAPI | None)](RemoteResponse, AsyncContextManager, metaclass=ABCMeta):
     """
     Generic base class for remote objects. Extracts key data from a remote API JSON response.
 
@@ -121,7 +121,7 @@ class RemoteObject[T: (RemoteAPI | None)](RemoteResponse, AsyncContextManager, A
         return hash(self.uri)
 
 
-class RemoteItem(RemoteObject, MusifyItem, ABC):
+class RemoteItem(RemoteObject, MusifyItem, metaclass=ABCMeta):
     """Generic base class for remote items. Extracts key data from a remote API JSON response."""
 
     __attributes_classes__ = (RemoteObject, MusifyItem)

--- a/musify/libraries/remote/core/base.py
+++ b/musify/libraries/remote/core/base.py
@@ -27,7 +27,7 @@ class RemoteObject[T: (RemoteAPI | None)](RemoteResponse, AsyncContextManager, m
     @property
     @abstractmethod
     def uri(self) -> str:
-        """The URI of this item/collection."""
+        """URI (Uniform Resource Indicator) is the unique identifier for this item/collection."""
         raise NotImplementedError
 
     @property

--- a/musify/libraries/remote/core/library.py
+++ b/musify/libraries/remote/core/library.py
@@ -2,7 +2,7 @@
 Functionality relating to a generic remote library.
 """
 import logging
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Collection, Mapping, Iterable
 from typing import Any, Literal, Self
 
@@ -30,7 +30,7 @@ type RestorePlaylistsType = (
 
 class RemoteLibrary[
     A: RemoteAPI, PL: RemotePlaylist, TR: RemoteTrack, AL: RemoteAlbum, AR: RemoteArtist
-](RemoteCollection[TR], Library[TR], ABC):
+](RemoteCollection[TR], Library[TR], metaclass=ABCMeta):
     """
     Represents a remote library, providing various methods for manipulating
     tracks and playlists across an entire remote library collection.

--- a/musify/libraries/remote/core/object.py
+++ b/musify/libraries/remote/core/object.py
@@ -5,7 +5,7 @@ Implements core :py:class:`MusifyItem` and :py:class:`MusifyCollection` classes 
 """
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
@@ -22,14 +22,14 @@ from musify.libraries.remote.core.exception import RemoteError
 from musify.utils import get_most_common_values
 
 
-class RemoteTrack(Track, RemoteItem, ABC):
+class RemoteTrack(Track, RemoteItem, metaclass=ABCMeta):
     """Extracts key ``track`` data from a remote API JSON response."""
 
     __slots__ = ()
     __attributes_classes__ = (Track, RemoteItem)
 
 
-class RemoteCollection[T: RemoteObject](MusifyCollection[T], ABC):
+class RemoteCollection[T: RemoteObject](MusifyCollection[T], metaclass=ABCMeta):
     """Generic class for storing a collection of remote objects."""
 
     __slots__ = ()
@@ -37,7 +37,7 @@ class RemoteCollection[T: RemoteObject](MusifyCollection[T], ABC):
     __attributes_ignore__ = ("items", "track_total")
 
 
-class RemoteCollectionLoader[T: RemoteObject](RemoteObject, RemoteCollection[T], ABC):
+class RemoteCollectionLoader[T: RemoteObject](RemoteCollection[T], RemoteObject, metaclass=ABCMeta):
     """Generic class for storing a collection of remote objects that can be loaded from an API response."""
 
     __slots__ = ()
@@ -113,7 +113,7 @@ class SyncResultRemotePlaylist(Result):
 PLAYLIST_SYNC_KINDS = Literal["new", "refresh", "sync"]
 
 
-class RemotePlaylist[T: RemoteTrack](Playlist[T], RemoteCollectionLoader[T], ABC):
+class RemotePlaylist[T: RemoteTrack](Playlist[T], RemoteCollectionLoader[T], metaclass=ABCMeta):
     """Extracts key ``playlist`` data from a remote API JSON response."""
 
     __slots__ = ()
@@ -250,7 +250,7 @@ class RemotePlaylist[T: RemoteTrack](Playlist[T], RemoteCollectionLoader[T], ABC
         raise NotImplementedError
 
 
-class RemoteAlbum[T: RemoteTrack](Album[T], RemoteCollectionLoader[T], ABC):
+class RemoteAlbum[T: RemoteTrack](Album[T], RemoteCollectionLoader[T], metaclass=ABCMeta):
     """Extracts key ``album`` data from a remote API JSON response."""
 
     __slots__ = ()
@@ -266,7 +266,7 @@ class RemoteAlbum[T: RemoteTrack](Album[T], RemoteCollectionLoader[T], ABC):
         raise NotImplementedError
 
 
-class RemoteArtist[T: (RemoteTrack, RemoteAlbum)](Artist[T], RemoteCollectionLoader[T], ABC):
+class RemoteArtist[T: (RemoteTrack, RemoteAlbum)](Artist[T], RemoteCollectionLoader[T], metaclass=ABCMeta):
     """Extracts key ``artist`` data from a remote API JSON response."""
 
     __slots__ = ()

--- a/musify/libraries/remote/core/object.py
+++ b/musify/libraries/remote/core/object.py
@@ -42,7 +42,6 @@ class RemoteCollectionLoader[T: RemoteObject](RemoteCollection[T], RemoteObject,
 
     __slots__ = ()
     __attributes_classes__ = (RemoteObject, RemoteCollection)
-    __attributes_ignore__ = "_total"
 
     def __eq__(self, __collection: RemoteObject | MusifyCollection | Iterable[T]):
         if isinstance(__collection, RemoteObject):

--- a/musify/libraries/remote/core/processors/wrangle.py
+++ b/musify/libraries/remote/core/processors/wrangle.py
@@ -1,7 +1,7 @@
 """
 Convert and validate remote ID and item types according to specific remote implementations.
 """
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
 from typing import Any
 
@@ -11,7 +11,7 @@ from musify.libraries.remote.core.exception import RemoteObjectTypeError
 from musify.libraries.remote.core.types import APIInputValue
 
 
-class RemoteDataWrangler(ABC):
+class RemoteDataWrangler(metaclass=ABCMeta):
     """Convert and validate remote ID and item types according to specific remote implementations."""
 
     __slots__ = ()

--- a/musify/libraries/remote/core/response.py
+++ b/musify/libraries/remote/core/response.py
@@ -2,14 +2,14 @@
 Just the core abstract class for the :py:mod:`Remote` module.
 Placed here separately to avoid circular import logic issues.
 """
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from typing import Any
 
 from musify.core.base import MusifyObject
 from musify.libraries.remote.core.enum import RemoteObjectType
 
 
-class RemoteResponse(MusifyObject, ABC):
+class RemoteResponse(MusifyObject, metaclass=ABCMeta):
 
     __slots__ = ()
 

--- a/musify/libraries/remote/spotify/api/api.py
+++ b/musify/libraries/remote/spotify/api/api.py
@@ -120,6 +120,7 @@ class SpotifyAPI(SpotifyAPIMisc, SpotifyAPIItems, SpotifyAPIPlaylists):
 
         super().__init__(authoriser=authoriser, wrangler=wrangler, cache=cache)
 
+    # noinspection PyAsyncCall
     async def _setup_cache(self) -> None:
         if not isinstance(self.handler.session, CachedSession):
             return

--- a/musify/libraries/remote/spotify/api/base.py
+++ b/musify/libraries/remote/spotify/api/base.py
@@ -1,7 +1,7 @@
 """
 Base functionality to be shared by all classes that implement :py:class:`RemoteAPI` functionality for Spotify.
 """
-from abc import ABC
+from abc import ABCMeta
 from collections.abc import Collection, MutableMapping, Iterable
 from typing import Any
 
@@ -15,7 +15,7 @@ from musify.libraries.remote.core.enum import RemoteObjectType
 from musify.utils import to_collection
 
 
-class SpotifyAPIBase(RemoteAPI, ABC):
+class SpotifyAPIBase(RemoteAPI, metaclass=ABCMeta):
     """Base functionality required for all endpoint functions for the Spotify API"""
 
     __slots__ = ()

--- a/musify/libraries/remote/spotify/api/item.py
+++ b/musify/libraries/remote/spotify/api/item.py
@@ -2,7 +2,7 @@
 Implements endpoints for getting items from the Spotify API.
 """
 import re
-from abc import ABC
+from abc import ABCMeta
 from collections.abc import Collection, Mapping, MutableMapping
 from copy import copy
 from itertools import batched
@@ -26,7 +26,7 @@ except ImportError:
 ARTIST_ALBUM_TYPES = {"album", "single", "compilation", "appears_on"}
 
 
-class SpotifyAPIItems(SpotifyAPIBase, ABC):
+class SpotifyAPIItems(SpotifyAPIBase, metaclass=ABCMeta):
 
     __slots__ = ()
 

--- a/musify/libraries/remote/spotify/api/misc.py
+++ b/musify/libraries/remote/spotify/api/misc.py
@@ -2,7 +2,7 @@
 Implements all required non-items and non-playlist endpoints from the Spotify API.
 """
 import logging
-from abc import ABC
+from abc import ABCMeta
 from collections.abc import MutableMapping
 from typing import Any
 
@@ -12,7 +12,7 @@ from musify.types import Number
 from musify.utils import limit_value
 
 
-class SpotifyAPIMisc(SpotifyAPIBase, ABC):
+class SpotifyAPIMisc(SpotifyAPIBase, metaclass=ABCMeta):
 
     __slots__ = ()
 

--- a/musify/libraries/remote/spotify/api/playlist.py
+++ b/musify/libraries/remote/spotify/api/playlist.py
@@ -1,7 +1,7 @@
 """
 Implements endpoints for manipulating playlists with the Spotify API.
 """
-from abc import ABC
+from abc import ABCMeta
 from collections.abc import Collection, Mapping
 from itertools import batched
 from typing import Any
@@ -14,7 +14,7 @@ from musify.libraries.remote.spotify.api.base import SpotifyAPIBase
 from musify.utils import limit_value
 
 
-class SpotifyAPIPlaylists(SpotifyAPIBase, ABC):
+class SpotifyAPIPlaylists(SpotifyAPIBase, metaclass=ABCMeta):
     """API endpoints for processing collections i.e. playlists, albums, shows, and audiobooks"""
 
     __slots__ = ()

--- a/musify/libraries/remote/spotify/base.py
+++ b/musify/libraries/remote/spotify/base.py
@@ -3,7 +3,7 @@ Core abstract classes for the :py:mod:`Spotify` module.
 
 These define the foundations of any Spotify object or item.
 """
-from abc import ABC
+from abc import ABCMeta
 
 from musify.libraries.remote.core.base import RemoteObject, RemoteItem
 from musify.libraries.remote.core.enum import RemoteObjectType
@@ -11,7 +11,7 @@ from musify.libraries.remote.core.exception import RemoteObjectTypeError, Remote
 from musify.libraries.remote.spotify.api import SpotifyAPI
 
 
-class SpotifyObject(RemoteObject[SpotifyAPI], ABC):
+class SpotifyObject(RemoteObject[SpotifyAPI], metaclass=ABCMeta):
     """Generic base class for Spotify-stored objects. Extracts key data from a Spotify API JSON response."""
 
     __slots__ = ()
@@ -53,7 +53,7 @@ class SpotifyObject(RemoteObject[SpotifyAPI], ABC):
             raise RemoteObjectTypeError("Response type invalid", kind=kind, value=self.response.get("type"))
 
 
-class SpotifyItem(SpotifyObject, RemoteItem, ABC):
+class SpotifyItem(SpotifyObject, RemoteItem, metaclass=ABCMeta):
     """Generic base class for Spotify-stored items. Extracts key data from a Spotify API JSON response."""
 
     __slots__ = ()

--- a/musify/libraries/remote/spotify/object.py
+++ b/musify/libraries/remote/spotify/object.py
@@ -3,7 +3,7 @@ Implements all :py:mod:`Remote` object types for Spotify.
 """
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable, MutableMapping, Mapping, Collection
 from copy import copy, deepcopy
 from datetime import datetime
@@ -251,7 +251,7 @@ class SpotifyTrack(SpotifyItem, RemoteTrack):
         self.__init__(response=response, api=self.api)
 
 
-class SpotifyCollectionLoader[T: SpotifyObject](RemoteCollectionLoader[T], SpotifyObject, ABC):
+class SpotifyCollectionLoader[T: SpotifyObject](RemoteCollectionLoader[T], SpotifyObject, metaclass=ABCMeta):
     """Generic class for storing a collection of Spotify objects that can be loaded from an API response."""
 
     __slots__ = ()

--- a/musify/libraries/remote/spotify/object.py
+++ b/musify/libraries/remote/spotify/object.py
@@ -391,7 +391,7 @@ class SpotifyPlaylist(SpotifyCollectionLoader[SpotifyTrack], RemotePlaylist[Spot
     """
 
     __slots__ = ("_tracks",)
-    __attributes_ignore__ = "date_added"
+    __attributes_ignore__ = ("date_added",)
 
     @staticmethod
     def _validate_item_type(items: Any | Iterable[Any]) -> bool:

--- a/musify/processors/base.py
+++ b/musify/processors/base.py
@@ -2,7 +2,7 @@
 Base classes for all processors in this module. Also contains decorators for use in implementations.
 """
 import logging
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping, Callable, Collection, Iterable, MutableSequence
 from functools import partial, update_wrapper
 from typing import Any, Optional
@@ -13,13 +13,13 @@ from musify.processors.exception import ProcessorLookupError
 from musify.utils import get_user_input, get_max_width, align_string
 
 
-class Processor(PrettyPrinter, ABC):
+class Processor(PrettyPrinter, metaclass=ABCMeta):
     """Generic base class for processors"""
 
     __slots__ = ()
 
 
-class InputProcessor(Processor, ABC):
+class InputProcessor(Processor, metaclass=ABCMeta):
     """
     Processor that gets user input as part of it processing.
 
@@ -81,7 +81,7 @@ class dynamicprocessormethod:
 
 
 # noinspection SpellCheckingInspection
-class DynamicProcessor(Processor, ABC):
+class DynamicProcessor(Processor, metaclass=ABCMeta):
     """
     Base class for implementations with :py:func:`dynamicprocessormethod` methods.
 
@@ -159,7 +159,7 @@ class DynamicProcessor(Processor, ABC):
         return self._processor_method(*args, **kwargs)
 
 
-class Filter[T](Processor, ABC):
+class Filter[T](Processor, metaclass=ABCMeta):
     """Base class for filtering down values based on some settings"""
 
     __slots__ = ("_transform",)
@@ -197,7 +197,7 @@ class Filter[T](Processor, ABC):
         return self.ready
 
 
-class FilterComposite[T](Filter[T], Collection[Filter], ABC):
+class FilterComposite[T](Filter[T], Collection[Filter], metaclass=ABCMeta):
     """Composite filter which filters based on many :py:class:`Filter` objects"""
 
     __slots__ = ("filters",)

--- a/musify/processors/limit.py
+++ b/musify/processors/limit.py
@@ -153,7 +153,6 @@ class ItemLimiter(DynamicProcessor):
                 raise LimiterProcessorError("The given item cannot be limited on length as it does not have a length.")
 
             factors = (1, 60, 60, 24, 7)[:self.kind.value % 10]
-            # noinspection PyUnresolvedReferences
             return item.length / reduce(mul, factors, 1)
 
         elif 20 <= self.kind.value < 30:

--- a/musify/utils.py
+++ b/musify/utils.py
@@ -264,7 +264,7 @@ def clean_kwargs(func: Callable, kwargs: dict[str, Any]) -> None:
             kwargs.pop(key)
 
 
-def required_modules_installed(modules: list, this: Any = None) -> bool:
+def required_modules_installed(modules: list, this: object = None) -> bool:
     """Check the required modules are installed, raise :py:class:`MusifyImportError` if not."""
     modules_installed = all(module is not None for module in modules)
     if not modules_installed and this is not None:
@@ -272,7 +272,6 @@ def required_modules_installed(modules: list, this: Any = None) -> bool:
         if isinstance(this, str):
             message = f"Cannot run {this}. Required modules: {", ".join(names)}"
         else:
-            # noinspection PyUnresolvedReferences
             message = f"Cannot create {this.__class__.__name__} object. Required modules: {", ".join(names)}"
 
         raise MusifyImportError(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ dev = [
     "musify[test,docs]",
     "flake8",
     "grip",
+    "jupyterlab",
+    "ipywidgets",
 ]
 
 [project.urls]

--- a/tests/api/cache/backend/test_sqlite.py
+++ b/tests/api/cache/backend/test_sqlite.py
@@ -43,7 +43,6 @@ class SQLiteTester(BaseResponseTester):
 
         return key, value
 
-    # noinspection PyProtectedMember
     @classmethod
     def generate_response_from_item(
             cls, settings: RequestSettings, key: Any, value: Any, session: ClientSession = None
@@ -51,7 +50,6 @@ class SQLiteTester(BaseResponseTester):
         url = f"http://test.com/{settings.name}/{key[1]}"
         return cls._generate_response_from_item(url=url, key=key, value=value, session=session)
 
-    # noinspection PyProtectedMember
     @classmethod
     def generate_bad_response_from_item(
             cls, settings: RequestSettings, key: Any, value: Any, session: ClientSession = None
@@ -186,11 +184,6 @@ class TestSQLiteCache(SQLiteTester, ResponseCacheTester):
 
     @staticmethod
     def generate_response(settings: RequestSettings, session: ClientSession = None) -> ClientResponse:
-        key, value = TestSQLiteTable.generate_item(settings)
-        return TestSQLiteTable.generate_response_from_item(settings, key, value, session=session)
-
-    @staticmethod
-    def generate_repository(settings: RequestSettings, session: ClientSession = None) -> ClientResponse:
         key, value = TestSQLiteTable.generate_item(settings)
         return TestSQLiteTable.generate_response_from_item(settings, key, value, session=session)
 

--- a/tests/api/cache/backend/testers.py
+++ b/tests/api/cache/backend/testers.py
@@ -1,5 +1,5 @@
 import sqlite3
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from random import choice, randrange
 from typing import Any
 
@@ -17,7 +17,7 @@ REQUEST_SETTINGS = [
 ]
 
 
-class BaseResponseTester(ABC):
+class BaseResponseTester(metaclass=ABCMeta):
     """Base functionality for all test suites related to `api.cache` package."""
 
     @staticmethod
@@ -63,7 +63,7 @@ class BaseResponseTester(ABC):
         raise NotImplementedError
 
 
-class ResponseRepositoryTester(BaseResponseTester, ABC):
+class ResponseRepositoryTester(BaseResponseTester, metaclass=ABCMeta):
     """Run generic tests for :py:class:`ResponseRepository` implementations."""
 
     # noinspection PyArgumentList
@@ -305,7 +305,7 @@ class ResponseRepositoryTester(BaseResponseTester, ABC):
             assert not await repository.contains(key)
 
 
-class ResponseCacheTester(BaseResponseTester, ABC):
+class ResponseCacheTester(BaseResponseTester, metaclass=ABCMeta):
     """Run generic tests for :py:class:`ResponseCache` implementations."""
 
     # noinspection PyArgumentList
@@ -347,7 +347,8 @@ class ResponseCacheTester(BaseResponseTester, ABC):
         """Returns a repository for the given ``url`` from the given ``cache``."""
         raise NotImplementedError
 
-    async def test_init(self, cache: ResponseCache):
+    @staticmethod
+    async def test_init(cache: ResponseCache):
         assert cache.values()
         for repository in cache.values():
             assert await repository.count()

--- a/tests/api/cache/backend/utils.py
+++ b/tests/api/cache/backend/utils.py
@@ -33,10 +33,12 @@ class MockPaginatedRequestSettings(MockRequestSettings):
 
     @staticmethod
     def get_offset(url: str | URL) -> int:
+        """Extracts the offset for a paginated request from the given ``url``."""
         params = URL(url).query
         return int(params.get("offset", 0))
 
     @staticmethod
     def get_limit(url: str | URL) -> int:
+        """Extracts the limit for a paginated request from the given ``url``."""
         params = URL(url).query
         return int(params.get("limit", 0))

--- a/tests/core/base.py
+++ b/tests/core/base.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 
 import pytest
 
@@ -7,7 +7,7 @@ from musify.core.printer import PrettyPrinter
 from tests.core.printer import PrettyPrinterTester
 
 
-class MusifyItemTester(PrettyPrinterTester, ABC):
+class MusifyItemTester(PrettyPrinterTester, metaclass=ABCMeta):
     """Run generic tests for :py:class:`MusifyItem` implementations"""
 
     @abstractmethod

--- a/tests/core/enum.py
+++ b/tests/core/enum.py
@@ -1,11 +1,11 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Container
 
 from musify.core.base import MusifyObject
 from musify.core.enum import MusifyEnum, Fields, TagField, ALL_FIELDS, Field
 
 
-class EnumTester(ABC):
+class EnumTester(metaclass=ABCMeta):
     """Run generic tests for :py:class:`MusifyEnum` implementations"""
 
     @property
@@ -24,7 +24,7 @@ class EnumTester(ABC):
         assert self.cls.from_value(*all_enums, fail_on_many=False) == set(all_enums)
 
 
-class FieldTester(EnumTester, ABC):
+class FieldTester(EnumTester, metaclass=ABCMeta):
     """Run generic tests for :py:class:`Field` enum implementations"""
 
     @abstractmethod
@@ -64,7 +64,7 @@ class FieldTester(EnumTester, ABC):
             assert isinstance(getattr(reference_cls, name), property)
 
 
-class TagFieldTester(FieldTester, ABC):
+class TagFieldTester(FieldTester, metaclass=ABCMeta):
     """Run generic tests for :py:class:`TagField` enum implementations"""
 
     @property

--- a/tests/core/printer.py
+++ b/tests/core/printer.py
@@ -1,11 +1,11 @@
 import json
 import re
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 
 from musify.core.printer import PrettyPrinter
 
 
-class PrettyPrinterTester(ABC):
+class PrettyPrinterTester(metaclass=ABCMeta):
     """Run generic tests for :py:class:`PrettyPrinter` implementations"""
     dict_json_equal: bool = True
 

--- a/tests/libraries/core/collection.py
+++ b/tests/libraries/core/collection.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
 from copy import deepcopy
 from random import sample
@@ -17,7 +17,7 @@ from musify.libraries.remote.core.object import RemoteCollectionLoader
 from tests.core.printer import PrettyPrinterTester
 
 
-class MusifyCollectionTester(PrettyPrinterTester, ABC):
+class MusifyCollectionTester(PrettyPrinterTester, metaclass=ABCMeta):
     """
     Run generic tests for :py:class:`MusifyCollection` implementations.
     The collection must have 3 or more items and all items must be unique.
@@ -210,7 +210,7 @@ class MusifyCollectionTester(PrettyPrinterTester, ABC):
         assert collection.intersection(other) == collection.items
 
 
-class PlaylistTester(MusifyCollectionTester, ABC):
+class PlaylistTester(MusifyCollectionTester, metaclass=ABCMeta):
 
     @abstractmethod
     def playlist(self, *args, **kwargs) -> Playlist:
@@ -291,7 +291,7 @@ class PlaylistTester(MusifyCollectionTester, ABC):
         assert playlist[initial_count:] == other.items
 
 
-class LibraryTester(MusifyCollectionTester, ABC):
+class LibraryTester(MusifyCollectionTester, metaclass=ABCMeta):
     """
     Run generic tests for :py:class:`Library` implementations.
     The collection must have 3 or more playlists and all playlists must be unique.

--- a/tests/libraries/local/library/testers.py
+++ b/tests/libraries/local/library/testers.py
@@ -1,8 +1,8 @@
-from abc import ABC
+from abc import ABCMeta
 
 from tests.libraries.core.collection import LibraryTester
 from tests.libraries.local.track.testers import LocalCollectionTester
 
 
-class LocalLibraryTester(LibraryTester, LocalCollectionTester, ABC):
+class LocalLibraryTester(LibraryTester, LocalCollectionTester, metaclass=ABCMeta):
     pass

--- a/tests/libraries/local/playlist/testers.py
+++ b/tests/libraries/local/playlist/testers.py
@@ -1,8 +1,8 @@
-from abc import ABC
+from abc import ABCMeta
 
 from tests.libraries.core.collection import PlaylistTester
 from tests.libraries.local.track.testers import LocalCollectionTester
 
 
-class LocalPlaylistTester(PlaylistTester, LocalCollectionTester, ABC):
+class LocalPlaylistTester(PlaylistTester, LocalCollectionTester, metaclass=ABCMeta):
     pass

--- a/tests/libraries/local/track/testers.py
+++ b/tests/libraries/local/track/testers.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABCMeta
 from collections.abc import Iterable, Collection
 from random import randrange, sample
 
@@ -13,7 +13,7 @@ from tests.libraries.local.track.utils import random_tracks
 from tests.libraries.remote.spotify.api.mock import SpotifyMock
 
 
-class LocalCollectionTester(MusifyCollectionTester, ABC):
+class LocalCollectionTester(MusifyCollectionTester, metaclass=ABCMeta):
 
     @pytest.fixture
     def collection_merge_items(self) -> Iterable[LocalTrack]:

--- a/tests/libraries/remote/core/api.py
+++ b/tests/libraries/remote/core/api.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
 from copy import deepcopy
 from random import sample, choice
@@ -14,7 +14,7 @@ from musify.libraries.remote.core.factory import RemoteObjectFactory
 from tests.libraries.remote.core.utils import RemoteMock
 
 
-class RemoteAPIFixtures(ABC):
+class RemoteAPIFixtures(metaclass=ABCMeta):
     """Generic fixtures and properties for tests of :py:class:`RemoteAPI` implementations."""
 
     @property
@@ -72,7 +72,7 @@ class RemoteAPIFixtures(ABC):
         return api.collection_item_map[object_type].name.lower() + "s" if extend else None
 
 
-class RemoteAPIItemTester(ABC):
+class RemoteAPIItemTester(metaclass=ABCMeta):
     """Run generic tests for item methods of :py:class:`RemoteAPI` implementations."""
     ###########################################################################
     ## Assertions

--- a/tests/libraries/remote/core/library.py
+++ b/tests/libraries/remote/core/library.py
@@ -1,5 +1,5 @@
 import re
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Collection, Mapping
 from copy import copy, deepcopy
 from random import choice
@@ -17,7 +17,7 @@ from tests.libraries.remote.core.object import RemoteCollectionTester
 from tests.libraries.remote.core.utils import RemoteMock
 
 
-class RemoteLibraryTester(RemoteCollectionTester, LibraryTester, ABC):
+class RemoteLibraryTester(RemoteCollectionTester, LibraryTester, metaclass=ABCMeta):
 
     @abstractmethod
     def collection_merge_items(self, *args, **kwargs) -> list[RemoteTrack]:

--- a/tests/libraries/remote/core/object.py
+++ b/tests/libraries/remote/core/object.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
 from typing import Any
 
@@ -15,7 +15,7 @@ from tests.libraries.local.track.utils import random_tracks
 from tests.libraries.remote.core.utils import RemoteMock
 
 
-class RemoteCollectionTester(MusifyCollectionTester, ABC):
+class RemoteCollectionTester(MusifyCollectionTester, metaclass=ABCMeta):
 
     @abstractmethod
     def collection_merge_items(self, *args, **kwargs) -> Iterable[RemoteItem]:
@@ -60,7 +60,7 @@ class RemoteCollectionTester(MusifyCollectionTester, ABC):
             assert collection["this key does not exist"]
 
 
-class RemotePlaylistTester(RemoteCollectionTester, PlaylistTester, ABC):
+class RemotePlaylistTester(RemoteCollectionTester, PlaylistTester, metaclass=ABCMeta):
 
     @staticmethod
     def _get_payload_from_request(request: RequestCall) -> dict[str, Any] | None:

--- a/tests/libraries/remote/core/processors/check.py
+++ b/tests/libraries/remote/core/processors/check.py
@@ -1,5 +1,5 @@
 import re
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from itertools import batched
 from random import randrange, choice
 
@@ -20,7 +20,7 @@ from tests.libraries.remote.spotify.utils import random_uri, random_uris
 from tests.utils import random_str, get_stdout
 
 
-class RemoteItemCheckerTester(PrettyPrinterTester, ABC):
+class RemoteItemCheckerTester(PrettyPrinterTester, metaclass=ABCMeta):
     """Run generic tests for :py:class:`RemoteItemSearcher` implementations."""
 
     @pytest.fixture

--- a/tests/libraries/remote/core/processors/search.py
+++ b/tests/libraries/remote/core/processors/search.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable, Callable, Awaitable
 from copy import copy
 from urllib.parse import unquote
@@ -19,7 +19,7 @@ from tests.libraries.local.track.utils import random_track, random_tracks
 from tests.libraries.remote.core.utils import RemoteMock
 
 
-class RemoteItemSearcherTester(PrettyPrinterTester, ABC):
+class RemoteItemSearcherTester(PrettyPrinterTester, metaclass=ABCMeta):
     """Run generic tests for :py:class:`RemoteItemSearcher` implementations."""
 
     @pytest.fixture

--- a/tests/libraries/remote/core/utils.py
+++ b/tests/libraries/remote/core/utils.py
@@ -1,5 +1,5 @@
 import re
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
 from typing import Any, ContextManager
 
@@ -14,7 +14,7 @@ ALL_ID_TYPES = RemoteIDType.all()
 ALL_ITEM_TYPES = RemoteObjectType.all()
 
 
-class RemoteMock(aioresponses, ContextManager, ABC):
+class RemoteMock(aioresponses, ContextManager, metaclass=ABCMeta):
     """Generates responses and sets up Remote API requests mock"""
 
     range_start = 25

--- a/tests/libraries/remote/core/utils.py
+++ b/tests/libraries/remote/core/utils.py
@@ -107,7 +107,6 @@ class RemoteMock(aioresponses, ContextManager, metaclass=ABCMeta):
     def _get_match_from_method(actual: str, expected: str | None = None) -> bool:
         match = expected is None
         if not match:
-            # noinspection PyProtectedMember
             match = actual.upper() == expected.upper()
 
         return match

--- a/tests/libraries/remote/spotify/api/test_api.py
+++ b/tests/libraries/remote/spotify/api/test_api.py
@@ -77,7 +77,6 @@ class TestSpotifyAPI(SpotifyAPIFixtures):
             repository = choice(list(a.handler.session.cache.values()))
             await repository.count()  # just check this doesn't fail
 
-    # noinspection PyTestUnpassedFixture
     async def test_cache_repository_getter(self, cache: ResponseCache, api_mock: SpotifyMock):
         async with SpotifyAPI(
                 cache=cache,
@@ -262,7 +261,6 @@ class TestSpotifyAPI(SpotifyAPIFixtures):
     ###########################################################################
     ## Utilities: Caching
     ###########################################################################
-    # noinspection PyTestUnpassedFixture
     @pytest.mark.parametrize("object_type", [
         RemoteObjectType.PLAYLIST, RemoteObjectType.USER,
     ], ids=idfn)
@@ -284,7 +282,6 @@ class TestSpotifyAPI(SpotifyAPIFixtures):
         # skip when no repository found
         assert await api_cache._get_responses_from_cache(method="GET", url=url, id_list=id_list) == ([], [], id_list)
 
-    # noinspection PyTestUnpassedFixture
     @pytest.mark.parametrize("object_type", [
         RemoteObjectType.TRACK,
         RemoteObjectType.ALBUM,

--- a/tests/libraries/remote/spotify/api/test_item.py
+++ b/tests/libraries/remote/spotify/api/test_item.py
@@ -777,7 +777,6 @@ class TestSpotifyAPIItems(RemoteAPIItemTester, SpotifyAPIFixtures):
             analysis={response[self.id_key]: analysis},
         )
 
-    # noinspection PyTestUnpassedFixture
     @pytest.mark.parametrize("object_type", [RemoteObjectType.TRACK], ids=idfn)
     async def test_extend_tracks_many_mapping(
             self,
@@ -826,7 +825,6 @@ class TestSpotifyAPIItems(RemoteAPIItemTester, SpotifyAPIFixtures):
         )
         assert test.bpm is not None
 
-    # noinspection PyTestUnpassedFixture
     @pytest.mark.parametrize("object_type", [RemoteObjectType.TRACK], ids=idfn)
     async def test_extend_tracks_many_response(
             self,

--- a/tests/libraries/remote/spotify/object/testers.py
+++ b/tests/libraries/remote/spotify/object/testers.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable
 from typing import Any
 from urllib.parse import unquote
@@ -13,7 +13,7 @@ from tests.libraries.remote.core.object import RemoteCollectionTester
 from tests.libraries.remote.spotify.api.mock import SpotifyMock
 
 
-class SpotifyCollectionLoaderTester(RemoteCollectionTester, ABC):
+class SpotifyCollectionLoaderTester(RemoteCollectionTester, metaclass=ABCMeta):
 
     @abstractmethod
     def collection_merge_items(self, *args, **kwargs) -> Iterable[SpotifyItem]:

--- a/tests/libraries/remote/spotify/test_library.py
+++ b/tests/libraries/remote/spotify/test_library.py
@@ -84,7 +84,7 @@ class TestSpotifyLibrary(RemoteLibraryTester):
     ###########################################################################
     ## Enrich tests
     ###########################################################################
-    # noinspection PyMethodOverriding,PyTestUnpassedFixture
+    # noinspection PyTestUnpassedFixture
     @pytest.mark.slow
     async def test_enrich_tracks(self, library: SpotifyLibrary, api_mock: SpotifyMock, **kwargs):
         def validate_track_extras_not_enriched(t: SpotifyTrack) -> None:
@@ -179,7 +179,6 @@ class TestSpotifyLibrary(RemoteLibraryTester):
             assert len(album.response["tracks"]["items"]) == album.track_total
             assert len(album.tracks) == album.track_total
 
-    # noinspection PyMethodOverriding
     @pytest.mark.slow
     async def test_enrich_saved_artists(self, library: SpotifyLibrary, api_mock: SpotifyMock, **kwargs):
         # ensure artists are not enriched already

--- a/tests/log/test_logger.py
+++ b/tests/log/test_logger.py
@@ -72,6 +72,7 @@ def test_file_paths(logger: MusifyLogger):
     assert [basename(path) for path in logger.file_paths] == ["test1.log", "test2.log"]
 
 
+# noinspection PyTypeChecker
 @pytest.mark.skipif(tqdm is None, reason="required modules not installed")
 def test_getting_iterator_as_progress_bar(logger: MusifyLogger):
     handler = logging.StreamHandler(sys.stdout)
@@ -79,7 +80,7 @@ def test_getting_iterator_as_progress_bar(logger: MusifyLogger):
     logging.root.addHandler(handler)
     logger._bars.clear()
 
-    bar = logger.get_iterator(iterable=range(0, 50), initial=10, disable=True, file=sys.stderr)
+    bar: tqdm = logger.get_iterator(iterable=range(0, 50), initial=10, disable=True, file=sys.stderr)
 
     assert bar.iterable == range(0, 50)
     assert bar.n == 10

--- a/tests/processors/test_download.py
+++ b/tests/processors/test_download.py
@@ -25,6 +25,7 @@ class TestItemDownloadHelper(PrettyPrinterTester):
     @pytest.fixture
     def download_helper(self) -> ItemDownloadHelper:
         """Yields a valid :py:class:`RemoteItemDownloadHelper` for the current remote source as a pytest.fixture."""
+        # noinspection SpellCheckingInspection
         sites = [
             "https://bandcamp.com/search?q={}&item_type=t",
             "https://uk.7digital.com/search?q={}&f=9%2C2",

--- a/tests/processors/test_filter.py
+++ b/tests/processors/test_filter.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABCMeta
 from random import sample, shuffle, randrange
 
 import pytest
@@ -16,7 +16,7 @@ from tests.libraries.local.utils import path_track_all
 from tests.utils import random_str, path_resources
 
 
-class FilterTester(PrettyPrinterTester, ABC):
+class FilterTester(PrettyPrinterTester, metaclass=ABCMeta):
     pass
 
 


### PR DESCRIPTION
* fix some bad reference issues in how-to scripts
* switch back to using metaclass explicitly for ABC inheritance uses to fix inheritance typing issues
* add `last_modified` field as attribute to ignore when getting attributes to print on `LocalCollection` to improve performance