### PR TITLE
add wait time logic for request handler

### DIFF
--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -59,6 +59,9 @@ Added
   by the mislabelled :py:meth:`.MusifyCollection.outer_difference` method
 * :py:class:`.RemoteDataWrangler` and its implementations now handle URL objects from the ``yarl`` package
 * :py:meth:`.RemoteAPI.follow_playlist` method
+* Wait time logic for :py:class:`.RequestHandler`. This waits by a certain time after each request,
+  incrementing this wait time every time a 429 code is returned.
+  This allows better handling of rate limits, with the aim of preventing a lock out from a service.
 
 Changed
 -------

--- a/musify/api/cache/session.py
+++ b/musify/api/cache/session.py
@@ -56,6 +56,8 @@ class CachedSession(ClientSession):
         if json is not None:
             kwargs["data"] = payload.JsonPayload(json, dumps=self._json_serialize)
 
+        drop_kwargs = ("allow_redirects",)
+
         req = ClientRequest(
             method=method,
             url=url,
@@ -63,7 +65,7 @@ class CachedSession(ClientSession):
             response_class=self._response_class,
             session=self,
             trust_env=self.trust_env,
-            **kwargs,
+            **{k: v for k, v in kwargs.items() if k not in drop_kwargs},
         )
 
         repository = self.cache.get_repository_from_requests(req.request_info)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,14 +23,14 @@ from musify.types import UnitCollection
 from musify.utils import to_collection
 from tests.libraries.remote.core.utils import ALL_ITEM_TYPES
 from tests.libraries.remote.spotify.api.mock import SpotifyMock
-from tests.utils import idfn
+from tests.utils import idfn, path_resources
 
 
 # noinspection PyUnusedLocal
 @pytest.hookimpl
 def pytest_configure(config: pytest.Config):
     """Loads logging config"""
-    config_file = Path(__file__).parent.with_stem("logging").with_suffix(".yml")
+    config_file = path_resources.joinpath("test_logging").with_suffix(".yml")
     if not config_file.is_file():
         return
 
@@ -398,6 +398,13 @@ async def spotify_api(spotify_mock: SpotifyMock) -> SpotifyAPI:
     token = {"access_token": "fake access token", "token_type": "Bearer", "scope": "test-read"}
     # disable any token tests by settings test_* kwargs as appropriate
     api = SpotifyAPI(token=token, test_args=None, test_expiry=0, test_condition=None)
+
+    # force almost no backoff/wait settings
+    api.handler.backoff_start = 0.001
+    api.handler.backoff_factor = 1
+    api.handler.backoff_count = 10
+    api.handler.wait_time = 0
+    api.handler.wait_interval = 0
 
     async with api as a:
         spotify_mock.reset()

--- a/tests/libraries/remote/spotify/api/test_misc.py
+++ b/tests/libraries/remote/spotify/api/test_misc.py
@@ -116,7 +116,7 @@ class TestSpotifyAPIMisc:
         stdout = "\n".join(re.sub("\33.*?m", "", capfd.readouterr().out).strip().splitlines())
 
         # printed in blocks
-        blocks = [block for block in stdout.split("\n\n") if str(api_mock.url_ext) in block]
+        blocks = [block for block in stdout.split("\n\n\n")[-1].split("\n\n") if str(api_mock.url_ext) in block]
         assert len(blocks) == api_mock.total_requests
 
         # lines printed = total tracks + 1 extra for title

--- a/tests/log/test_logger.py
+++ b/tests/log/test_logger.py
@@ -26,7 +26,9 @@ def logger() -> MusifyLogger:
     for handler in logger.handlers:
         logger.removeHandler(handler)
 
-    return logger
+    logger.disable_bars = False
+    yield logger
+    logger.disable_bars = True
 
 
 def test_print(logger: MusifyLogger, capfd: pytest.CaptureFixture):
@@ -117,6 +119,7 @@ def test_tqdm_kwargs(logger: MusifyLogger):
         smoothing=0.5,
         position=3,
     )
+
     kwargs_processed = logger._get_tqdm_kwargs(**kwargs)
     assert kwargs_processed["initial"] == 10
     assert not kwargs_processed["disable"]
@@ -141,7 +144,7 @@ def test_tqdm_iterator_synchronous(logger: MusifyLogger):
     assert bar in logger._bars
 
     # adheres to disable_bars attribute
-    logger.disable_bars = False
+    logger.disable_bars = True
     bar = logger.get_synchronous_iterator(
         iterable=range(0, 50),
         initial=10,
@@ -154,13 +157,10 @@ def test_tqdm_iterator_synchronous(logger: MusifyLogger):
     )
 
     assert not bar.leave
-    assert not bar.disable
-    assert bar.ncols == 120
-    assert bar.colour == "blue"
-    assert bar.smoothing == 0.1
-    assert bar.pos == -3
+    assert bar.disable
+    assert bar.pos == 0
 
-    logger.disable_bars = True
+    logger.disable_bars = False
 
 
 @pytest.mark.skipif(tqdm is None, reason="required modules not installed")


### PR DESCRIPTION
 Wait time logic for :py:class:`.RequestHandler`. This waits by a certain time after each request,
  incrementing this wait time every time a 429 code is returned.
  This allows better handling of rate limits, with the aim of preventing a lock out from a service.